### PR TITLE
Add SQLite support with database adapter pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+sample.db

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1878,6 +1878,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri-plugin-sql = { version = "2", features = ["postgres"] }
+tauri-plugin-sql = { version = "2", features = ["postgres", "sqlite"] }
 tauri-plugin-store = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src/lib/components/connection-dialog.svelte
+++ b/src/lib/components/connection-dialog.svelte
@@ -339,9 +339,9 @@ const handleSubmit = async () => {
                             >mysql://user:pass@host:port/db</code
                         >
                         <br />
-                        • MongoDB:
+                        • SQLite:
                         <code class="text-xs"
-                            >mongodb://user:pass@host:port/db</code
+                            >sqlite:///path/to/database.db</code
                         >
                     </p>
                 </div>

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,0 +1,39 @@
+import type { DatabaseType, SchemaTable, SchemaColumn, SchemaIndex } from "$lib/types";
+import { PostgresAdapter } from "./postgres";
+import { SqliteAdapter } from "./sqlite";
+
+export interface DatabaseAdapter {
+	/** SQL query to list all tables in the database */
+	getSchemaQuery(): string;
+
+	/** SQL query to get column metadata for a table */
+	getColumnsQuery(table: string, schema: string): string;
+
+	/** SQL query to get index information for a table */
+	getIndexesQuery(table: string, schema: string): string;
+
+	/** SQL query to get foreign key information for a table (optional, some DBs include in columns query) */
+	getForeignKeysQuery?(table: string, schema: string): string;
+
+	/** Transform raw schema query results to SchemaTable[] */
+	parseSchemaResult(rows: unknown[]): SchemaTable[];
+
+	/** Transform raw columns query results to SchemaColumn[] */
+	parseColumnsResult(rows: unknown[], foreignKeys?: unknown[]): SchemaColumn[];
+
+	/** Transform raw indexes query results to SchemaIndex[] */
+	parseIndexesResult(rows: unknown[]): SchemaIndex[];
+}
+
+const adapters: Partial<Record<DatabaseType, DatabaseAdapter>> = {
+	postgres: new PostgresAdapter(),
+	sqlite: new SqliteAdapter(),
+};
+
+export function getAdapter(type: DatabaseType): DatabaseAdapter {
+	const adapter = adapters[type];
+	if (!adapter) {
+		throw new Error(`Database type "${type}" is not supported yet`);
+	}
+	return adapter;
+}

--- a/src/lib/db/postgres.ts
+++ b/src/lib/db/postgres.ts
@@ -1,0 +1,111 @@
+import type { DatabaseAdapter } from "./index";
+import type { SchemaTable, SchemaColumn, SchemaIndex } from "$lib/types";
+
+interface PostgresSchemaRow {
+	schema_name: string;
+	table_name: string;
+}
+
+interface PostgresColumnRow {
+	column_name: string;
+	data_type: string;
+	is_nullable: string;
+	column_default: string | null;
+	is_primary_key: boolean;
+	is_foreign_key: boolean;
+}
+
+interface PostgresIndexRow {
+	indexname: string;
+	indexdef: string;
+	schemaname: string;
+	tablename: string;
+}
+
+export class PostgresAdapter implements DatabaseAdapter {
+	getSchemaQuery(): string {
+		return `SELECT
+			table_schema AS schema_name,
+			table_name
+		FROM
+			information_schema.tables
+		WHERE
+			table_type = 'BASE TABLE'
+			AND table_schema NOT IN ('pg_catalog', 'information_schema')
+		ORDER BY
+			table_schema, table_name`;
+	}
+
+	getColumnsQuery(table: string, schema: string): string {
+		return `SELECT
+			column_name,
+			data_type,
+			is_nullable,
+			column_default,
+			(SELECT EXISTS (
+				SELECT 1 FROM information_schema.constraint_column_usage ccu
+				JOIN information_schema.table_constraints tc ON ccu.constraint_name = tc.constraint_name
+				WHERE ccu.column_name = c.column_name
+					AND ccu.table_schema = c.table_schema
+					AND ccu.table_name = c.table_name
+					AND tc.constraint_type = 'PRIMARY KEY'
+			)) as is_primary_key,
+			(SELECT EXISTS (
+				SELECT 1 FROM information_schema.constraint_column_usage ccu
+				JOIN information_schema.table_constraints tc ON ccu.constraint_name = tc.constraint_name
+				WHERE ccu.column_name = c.column_name
+					AND ccu.table_schema = c.table_schema
+					AND ccu.table_name = c.table_name
+					AND tc.constraint_type = 'FOREIGN KEY'
+			)) as is_foreign_key
+		FROM information_schema.columns c
+		WHERE table_name = '${table}' AND table_schema = '${schema}'
+		ORDER BY ordinal_position`;
+	}
+
+	getIndexesQuery(table: string, schema: string): string {
+		return `SELECT
+			indexname,
+			indexdef,
+			schemaname,
+			tablename
+		FROM pg_indexes
+		WHERE tablename = '${table}' AND schemaname = '${schema}'`;
+	}
+
+	parseSchemaResult(rows: unknown[]): SchemaTable[] {
+		return (rows as PostgresSchemaRow[]).map((row) => ({
+			name: row.table_name,
+			schema: row.schema_name,
+			type: "table" as const,
+			columns: [],
+			indexes: [],
+		}));
+	}
+
+	parseColumnsResult(rows: unknown[]): SchemaColumn[] {
+		return (rows as PostgresColumnRow[]).map((col) => ({
+			name: col.column_name,
+			type: col.data_type,
+			nullable: col.is_nullable === "YES",
+			defaultValue: col.column_default || undefined,
+			isPrimaryKey: col.is_primary_key,
+			isForeignKey: col.is_foreign_key,
+		}));
+	}
+
+	parseIndexesResult(rows: unknown[]): SchemaIndex[] {
+		return (rows as PostgresIndexRow[]).map((idx) => ({
+			name: idx.indexname,
+			columns: this.parseIndexColumns(idx.indexdef),
+			unique: idx.indexdef.includes("UNIQUE"),
+			type: "btree",
+		}));
+	}
+
+	private parseIndexColumns(indexdef: string): string[] {
+		const match = indexdef.match(/\((.*?)\)/);
+		if (!match) return [];
+		return match[1].split(",").map((col) => col.trim());
+	}
+}

--- a/src/lib/db/sqlite.ts
+++ b/src/lib/db/sqlite.ts
@@ -1,0 +1,95 @@
+import type { DatabaseAdapter } from "./index";
+import type { SchemaTable, SchemaColumn, SchemaIndex } from "$lib/types";
+
+interface SqliteSchemaRow {
+	name: string;
+	type: string;
+}
+
+interface SqliteColumnRow {
+	cid: number;
+	name: string;
+	type: string;
+	notnull: number;
+	dflt_value: string | null;
+	pk: number;
+}
+
+interface SqliteIndexRow {
+	seq: number;
+	name: string;
+	unique: number;
+	origin: string;
+	partial: number;
+}
+
+interface SqliteForeignKeyRow {
+	id: number;
+	seq: number;
+	table: string;
+	from: string;
+	to: string;
+	on_update: string;
+	on_delete: string;
+	match: string;
+}
+
+export class SqliteAdapter implements DatabaseAdapter {
+	getSchemaQuery(): string {
+		return `SELECT name, type FROM sqlite_master
+			WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+			ORDER BY name`;
+	}
+
+	getColumnsQuery(table: string, _schema: string): string {
+		// SQLite uses PRAGMA for table info
+		return `PRAGMA table_info('${table}')`;
+	}
+
+	getIndexesQuery(table: string, _schema: string): string {
+		return `PRAGMA index_list('${table}')`;
+	}
+
+	getForeignKeysQuery(table: string, _schema: string): string {
+		return `PRAGMA foreign_key_list('${table}')`;
+	}
+
+	parseSchemaResult(rows: unknown[]): SchemaTable[] {
+		return (rows as SqliteSchemaRow[]).map((row) => ({
+			name: row.name,
+			schema: "main", // SQLite uses "main" as the default schema
+			type: "table" as const,
+			columns: [],
+			indexes: [],
+		}));
+	}
+
+	parseColumnsResult(rows: unknown[], foreignKeys?: unknown[]): SchemaColumn[] {
+		const fkColumns = new Set<string>();
+		if (foreignKeys) {
+			for (const fk of foreignKeys as SqliteForeignKeyRow[]) {
+				fkColumns.add(fk.from);
+			}
+		}
+
+		return (rows as SqliteColumnRow[]).map((col) => ({
+			name: col.name,
+			type: col.type || "BLOB", // SQLite allows empty type
+			nullable: col.notnull === 0,
+			defaultValue: col.dflt_value || undefined,
+			isPrimaryKey: col.pk > 0,
+			isForeignKey: fkColumns.has(col.name),
+		}));
+	}
+
+	parseIndexesResult(rows: unknown[]): SchemaIndex[] {
+		return (rows as SqliteIndexRow[])
+			.filter((idx) => idx.name && !idx.name.startsWith("sqlite_"))
+			.map((idx) => ({
+				name: idx.name,
+				columns: [], // Would need separate PRAGMA index_info call for columns
+				unique: idx.unique === 1,
+				type: "btree",
+			}));
+	}
+}


### PR DESCRIPTION
- Add sqlite feature to tauri-plugin-sql in Cargo.toml
- Create DatabaseAdapter interface for abstracting DB-specific queries
- Implement PostgresAdapter (extracted from existing code)
- Implement SqliteAdapter using PRAGMA statements
- Update database.svelte.ts to use adapter pattern
- Add SQLite to connection string help text

The adapter pattern isolates database-specific logic into separate files, making it easy to add support for new database types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)