### PR TITLE
Add resizable panels between query editor and results

### DIFF
--- a/src/lib/components/query-editor.svelte
+++ b/src/lib/components/query-editor.svelte
@@ -5,6 +5,7 @@
 	import { Badge } from "$lib/components/ui/badge";
 	import SaveQueryDialog from "$lib/components/save-query-dialog.svelte";
 	import MonacoEditor from "$lib/components/monaco-editor.svelte";
+	import * as Resizable from "$lib/components/ui/resizable";
 
 	const db = useDatabase();
 	let showSaveDialog = $state(false);
@@ -27,10 +28,10 @@
 	};
 </script>
 
-<div class="flex flex-col h-full">
+<div class="flex flex-col h-full overflow-hidden">
 	{#if db.activeQueryTab}
 		<!-- Toolbar -->
-		<div class="flex items-center justify-between p-2 border-b bg-muted/30">
+		<div class="flex items-center justify-between p-2 border-b bg-muted/30 shrink-0">
 			<div class="flex items-center gap-3 text-xs text-muted-foreground">
 				{#if db.activeQueryTab.results}
 					<span class="flex items-center gap-1">
@@ -58,63 +59,71 @@
 			</div>
 		</div>
 
-		<div class="flex-1 flex flex-col">
-			<div class="h-64 border-b">
-				{#key db.activeQueryTabId}
-					<MonacoEditor
-						bind:value={db.activeQueryTab.query}
-						schema={db.activeSchema}
-						onExecute={handleExecute}
-					/>
-				{/key}
-			</div>
+		<Resizable.PaneGroup direction="vertical" class="flex-1 min-h-0">
+			<!-- Editor Pane -->
+			<Resizable.Pane defaultSize={40} minSize={15}>
+				<div class="h-full">
+					{#key db.activeQueryTabId}
+						<MonacoEditor
+							bind:value={db.activeQueryTab.query}
+							schema={db.activeSchema}
+							onExecute={handleExecute}
+						/>
+					{/key}
+				</div>
+			</Resizable.Pane>
 
-			<div class="h-full flex flex-col">
-				{#if db.activeQueryTab.results}
-					<div class="flex items-center justify-end p-2 border-b bg-muted/30">
-						<div class="flex items-center gap-2">
-							<Button size="sm" variant="outline" class="h-7 gap-1" onclick={() => handleExport("csv")}>
-								<DownloadIcon class="size-3" />
-								CSV
-							</Button>
-							<Button size="sm" variant="outline" class="h-7 gap-1" onclick={() => handleExport("json")}>
-								<DownloadIcon class="size-3" />
-								JSON
-							</Button>
+			<Resizable.Handle withHandle />
+
+			<!-- Results Pane -->
+			<Resizable.Pane defaultSize={60} minSize={15}>
+				<div class="h-full flex flex-col overflow-hidden">
+					{#if db.activeQueryTab.results}
+						<div class="flex items-center justify-end p-2 border-b bg-muted/30 shrink-0">
+							<div class="flex items-center gap-2">
+								<Button size="sm" variant="outline" class="h-7 gap-1" onclick={() => handleExport("csv")}>
+									<DownloadIcon class="size-3" />
+									CSV
+								</Button>
+								<Button size="sm" variant="outline" class="h-7 gap-1" onclick={() => handleExport("json")}>
+									<DownloadIcon class="size-3" />
+									JSON
+								</Button>
+							</div>
 						</div>
-					</div>
 
-					<div class="flex-1 overflow-auto">
-						<table class="w-full text-sm">
-							<thead class="sticky top-0 bg-muted border-b">
-								<tr>
-									{#each db.activeQueryTab.results.columns as column}
-										<th class="px-4 py-2 text-left font-medium">{column}</th>
-									{/each}
-								</tr>
-							</thead>
-							<tbody>
-								{#each db.activeQueryTab.results.rows as row, i}
-									<tr class={["border-b hover:bg-muted/50", i % 2 === 0 && "bg-muted/20"]}>
+						<div class="flex-1 overflow-auto min-h-0">
+							<table class="w-full text-sm">
+								<thead class="sticky top-0 bg-muted border-b">
+									<tr>
 										{#each db.activeQueryTab.results.columns as column}
-											<td class="px-4 py-2">{row[column]}</td>
+											<th class="px-4 py-2 text-left font-medium">{column}</th>
 										{/each}
 									</tr>
-								{/each}
-							</tbody>
-						</table>
-					</div>
-				{:else}
-					<div class="flex-1 flex items-center justify-center text-muted-foreground">
-						<div class="text-center">
-							<PlayIcon class="size-12 mx-auto mb-2 opacity-20" />
-							<p class="text-sm">Execute a query to see results</p>
-							<p class="text-xs mt-1 text-muted-foreground">Press ⌘+Enter to run</p>
+								</thead>
+								<tbody>
+									{#each db.activeQueryTab.results.rows as row, i}
+										<tr class={["border-b hover:bg-muted/50", i % 2 === 0 && "bg-muted/20"]}>
+											{#each db.activeQueryTab.results.columns as column}
+												<td class="px-4 py-2">{row[column]}</td>
+											{/each}
+										</tr>
+									{/each}
+								</tbody>
+							</table>
 						</div>
-					</div>
-				{/if}
-			</div>
-		</div>
+					{:else}
+						<div class="flex-1 flex items-center justify-center text-muted-foreground">
+							<div class="text-center">
+								<PlayIcon class="size-12 mx-auto mb-2 opacity-20" />
+								<p class="text-sm">Execute a query to see results</p>
+								<p class="text-xs mt-1 text-muted-foreground">Press ⌘+Enter to run</p>
+							</div>
+						</div>
+					{/if}
+				</div>
+			</Resizable.Pane>
+		</Resizable.PaneGroup>
 	{:else}
 		<div class="flex-1 flex items-center justify-center text-muted-foreground">
 			<div class="text-center">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,10 +13,10 @@
 <ModeWatcher />
 <Toaster position="bottom-right" theme={"dark"} richColors />
 
-<Sidebar.Provider class="[--header-height:calc(--spacing(8))] flex-col">
+<Sidebar.Provider class="[--header-height:calc(--spacing(8))] flex-col h-svh overflow-hidden">
     <AppHeader />
 
-    <div class="flex w-full min-h-svh overflow-hidden">
+    <div class="flex w-full flex-1 min-h-0 overflow-hidden">
         {@render children()}
     </div>
 </Sidebar.Provider>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,7 +56,7 @@
 <Toaster position="bottom-right" richColors />
 
 <SidebarLeft />
-<SidebarInset class="flex flex-col">
+<SidebarInset class="flex flex-col h-full overflow-hidden">
     {#if db.activeConnectionId}
         <!-- Unified Tab Bar -->
         <div class="flex items-center gap-2 p-2 border-b bg-muted/30 overflow-hidden">


### PR DESCRIPTION
## Summary
- Implement resizable vertical panels between the Monaco SQL editor and query results table using shadcn-svelte's Resizable component
- Constrain the entire layout to viewport height to prevent page-level scrolling
- Editor pane defaults to 40% height, results to 60%, both with 15% minimum size

## Test plan
- [ ] Open a query tab and verify the drag handle appears between editor and results
- [ ] Drag the handle up/down to resize the panels
- [ ] Verify panels respect the 15% minimum size constraint
- [ ] Confirm the page does not scroll vertically regardless of content size
- [ ] Test with query results that have many rows to verify scrolling is contained within the results pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)