### PR TITLE
Fix reconnecting dialog reopening on Escape key

### DIFF
--- a/src/lib/components/app-header.svelte
+++ b/src/lib/components/app-header.svelte
@@ -86,8 +86,11 @@
                                 ]}
                                 onclick={() =>
                                     handleConnectionClick(connection)}
-                                onkeyup={() =>
-                                    handleConnectionClick(connection)}
+                                onkeyup={(e) => {
+                                    if (e.key !== "Escape") {
+                                        handleConnectionClick(connection);
+                                    }
+                                }}
                             >
                                 <span class="pr-4">{connection.name}</span>
                                 <Button


### PR DESCRIPTION
## Summary
- Fix bug where pressing Escape to close the reconnecting dialog would immediately reopen it
- The keyup event was bubbling to the connection button after dialog close, triggering `handleConnectionClick`
- Filter out Escape key from the `onkeyup` handler

## Test plan
- [ ] Open a persisted connection (one without active database)
- [ ] Press Escape to close the reconnecting dialog
- [ ] Verify dialog stays closed
- [ ] Verify X button still works to close

🤖 Generated with [Claude Code](https://claude.com/claude-code)