### PR TITLE
Add write operations support (INSERT/UPDATE/DELETE)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:app:allow-set-app-theme",
     "core:window:allow-set-theme",
     "sql:default",
+    "sql:allow-execute",
     "core:window:default",
     "core:window:allow-start-dragging",
     "store:default",

--- a/src/lib/components/editable-cell.svelte
+++ b/src/lib/components/editable-cell.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { Input } from "$lib/components/ui/input";
+	import { LoaderIcon } from "@lucide/svelte";
+
+	interface Props {
+		value: unknown;
+		isEditable?: boolean;
+		onSave: (newValue: string) => Promise<void>;
+	}
+
+	let { value, isEditable = false, onSave }: Props = $props();
+
+	let isEditing = $state(false);
+	let editValue = $state('');
+	let isSaving = $state(false);
+	let inputRef = $state<HTMLInputElement | null>(null);
+
+	function startEditing() {
+		if (!isEditable) return;
+		editValue = formatValue(value);
+		isEditing = true;
+		// Focus input after it renders
+		setTimeout(() => inputRef?.focus(), 0);
+	}
+
+	function formatValue(val: unknown): string {
+		if (val === null || val === undefined) return '';
+		if (typeof val === 'object') return JSON.stringify(val);
+		return String(val);
+	}
+
+	async function handleSave() {
+		const originalValue = formatValue(value);
+		if (editValue === originalValue) {
+			isEditing = false;
+			return;
+		}
+
+		isSaving = true;
+		try {
+			await onSave(editValue);
+			isEditing = false;
+		} finally {
+			isSaving = false;
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			handleSave();
+		} else if (e.key === 'Escape') {
+			editValue = formatValue(value);
+			isEditing = false;
+		}
+	}
+
+	function handleBlur() {
+		if (!isSaving) {
+			handleSave();
+		}
+	}
+</script>
+
+{#if isEditing && isEditable}
+	<div class="flex items-center gap-1">
+		<Input
+			bind:ref={inputRef}
+			bind:value={editValue}
+			onblur={handleBlur}
+			onkeydown={handleKeydown}
+			disabled={isSaving}
+			class="h-6 text-xs py-0 px-1"
+		/>
+		{#if isSaving}
+			<LoaderIcon class="size-3 animate-spin shrink-0" />
+		{/if}
+	</div>
+{:else}
+	<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+	<span
+		class={isEditable ? "cursor-pointer hover:bg-muted rounded px-1 -mx-1" : ""}
+		ondblclick={startEditing}
+		role={isEditable ? "button" : undefined}
+		tabindex={isEditable ? 0 : undefined}
+		onkeydown={(e) => e.key === 'Enter' && startEditing()}
+	>
+		{#if value === null}
+			<span class="text-muted-foreground italic">NULL</span>
+		{:else if value === undefined || value === ''}
+			<span class="text-muted-foreground">&nbsp;</span>
+		{:else if typeof value === 'object'}
+			{JSON.stringify(value)}
+		{:else}
+			{value}
+		{/if}
+	</span>
+{/if}

--- a/src/lib/components/insert-row-dialog.svelte
+++ b/src/lib/components/insert-row-dialog.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import { untrack } from "svelte";
+	import { Button } from "$lib/components/ui/button";
+	import * as Dialog from "$lib/components/ui/dialog/index.js";
+	import { Input } from "$lib/components/ui/input";
+	import { Label } from "$lib/components/ui/label";
+	import { useDatabase } from "$lib/hooks/database.svelte.js";
+	import { toast } from "svelte-sonner";
+	import { LoaderIcon } from "@lucide/svelte";
+	import type { SchemaColumn } from "$lib/types";
+
+	interface Props {
+		open: boolean;
+		sourceTable: { schema: string; name: string; primaryKeys: string[] };
+		columns: SchemaColumn[];
+		onClose: () => void;
+		onSuccess: () => void;
+	}
+
+	let { open = $bindable(), sourceTable, columns, onClose, onSuccess }: Props = $props();
+
+	const db = useDatabase();
+	let isInserting = $state(false);
+	let values = $state<Record<string, string>>({});
+	let previousOpen = false;
+
+	// Reset form when dialog opens (only on transition from closed to open)
+	$effect(() => {
+		const isOpening = open && !previousOpen;
+		untrack(() => {
+			previousOpen = open;
+		});
+		if (isOpening) {
+			const newValues: Record<string, string> = {};
+			columns.forEach(col => {
+				newValues[col.name] = '';
+			});
+			values = newValues;
+		}
+	});
+
+	async function handleInsert() {
+		// Filter out empty values for nullable columns
+		const insertValues: Record<string, unknown> = {};
+		for (const col of columns) {
+			const value = values[col.name];
+			if (value !== '' && value !== undefined) {
+				insertValues[col.name] = value;
+			} else if (!col.nullable && !col.defaultValue) {
+				toast.error(`${col.name} is required`);
+				return;
+			}
+		}
+
+		if (Object.keys(insertValues).length === 0) {
+			toast.error('Please fill in at least one field');
+			return;
+		}
+
+		isInserting = true;
+
+		const result = await db.insertRow(sourceTable, insertValues);
+
+		if (result.success) {
+			toast.success(result.lastInsertId
+				? `Row inserted (ID: ${result.lastInsertId})`
+				: 'Row inserted');
+			open = false;
+			onSuccess();
+		} else {
+			toast.error(`Failed to insert: ${result.error}`);
+		}
+
+		isInserting = false;
+	}
+
+	function handleCancel() {
+		open = false;
+		onClose();
+	}
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="sm:max-w-lg max-h-[80vh] overflow-hidden flex flex-col">
+		<Dialog.Header>
+			<Dialog.Title>Insert Row</Dialog.Title>
+			<Dialog.Description>
+				Add a new row to {sourceTable.schema}.{sourceTable.name}
+			</Dialog.Description>
+		</Dialog.Header>
+		<div class="overflow-y-auto flex-1 py-4">
+			<div class="grid gap-4">
+				{#each columns as col}
+					<div class="grid gap-2">
+						<Label for={col.name} class="flex items-center gap-2">
+							{col.name}
+							<span class="text-xs text-muted-foreground font-normal">
+								{col.type}
+								{#if col.nullable}
+									(optional)
+								{/if}
+							</span>
+						</Label>
+						<Input
+							id={col.name}
+							bind:value={values[col.name]}
+							placeholder={col.defaultValue ? `Default: ${col.defaultValue}` : undefined}
+							disabled={isInserting}
+						/>
+					</div>
+				{/each}
+			</div>
+		</div>
+		<Dialog.Footer>
+			<Button variant="outline" onclick={handleCancel} disabled={isInserting}>
+				Cancel
+			</Button>
+			<Button onclick={handleInsert} disabled={isInserting}>
+				{#if isInserting}
+					<LoaderIcon class="size-4 mr-2 animate-spin" />
+				{/if}
+				Insert
+			</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/row-actions.svelte
+++ b/src/lib/components/row-actions.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { Button } from "$lib/components/ui/button";
+	import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
+	import { MoreVerticalIcon, TrashIcon, LoaderIcon } from "@lucide/svelte";
+
+	interface Props {
+		onDelete: () => Promise<void>;
+		isDeleting?: boolean;
+	}
+
+	let { onDelete, isDeleting = false }: Props = $props();
+</script>
+
+<DropdownMenu.Root>
+	<DropdownMenu.Trigger>
+		{#snippet child({ props })}
+			<Button {...props} variant="ghost" size="icon" class="h-6 w-6" disabled={isDeleting}>
+				{#if isDeleting}
+					<LoaderIcon class="size-3 animate-spin" />
+				{:else}
+					<MoreVerticalIcon class="size-3" />
+				{/if}
+			</Button>
+		{/snippet}
+	</DropdownMenu.Trigger>
+	<DropdownMenu.Content align="start">
+		<DropdownMenu.Item onclick={onDelete} class="text-destructive focus:text-destructive">
+			<TrashIcon class="size-4 mr-2" />
+			Delete Row
+		</DropdownMenu.Item>
+	</DropdownMenu.Content>
+</DropdownMenu.Root>

--- a/src/lib/db/query-utils.ts
+++ b/src/lib/db/query-utils.ts
@@ -1,0 +1,36 @@
+export type QueryType = 'select' | 'insert' | 'update' | 'delete' | 'other';
+
+/**
+ * Detects the type of SQL query based on its first keyword.
+ */
+export function detectQueryType(query: string): QueryType {
+	const trimmed = query.trim().toUpperCase();
+	if (trimmed.startsWith('SELECT')) return 'select';
+	if (trimmed.startsWith('INSERT')) return 'insert';
+	if (trimmed.startsWith('UPDATE')) return 'update';
+	if (trimmed.startsWith('DELETE')) return 'delete';
+	return 'other';
+}
+
+/**
+ * Returns true if the query is a write operation (INSERT, UPDATE, DELETE).
+ */
+export function isWriteQuery(query: string): boolean {
+	const type = detectQueryType(query);
+	return type === 'insert' || type === 'update' || type === 'delete';
+}
+
+/**
+ * Extracts the table name from a simple SELECT query.
+ * Returns null if the table cannot be determined.
+ */
+export function extractTableFromSelect(query: string): { schema?: string; table: string } | null {
+	// Match: FROM [schema.]table
+	// Handles: FROM table, FROM schema.table, FROM "table", FROM schema."table"
+	const match = query.match(/\bFROM\s+(?:"?([a-z_][a-z0-9_]*)"?\.)?"?([a-z_][a-z0-9_]*)"?/i);
+	if (!match) return null;
+	return {
+		schema: match[1] || undefined,
+		table: match[2]
+	};
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 import type Database from "@tauri-apps/plugin-sql";
+import type { QueryType } from './db/query-utils';
 
 export type DatabaseType = "postgres" | "mysql" | "sqlite" | "mongodb" | "mariadb" | "mssql";
 
@@ -64,6 +65,13 @@ export interface QueryResult {
 	totalRows: number;
 	executionTime: number;
 	affectedRows?: number;
+	lastInsertId?: number;
+	queryType?: QueryType;
+	sourceTable?: {
+		schema: string;
+		name: string;
+		primaryKeys: string[];
+	};
 	page: number;
 	pageSize: number;
 	totalPages: number;


### PR DESCRIPTION
## Summary
- Detect query type and use `database.execute()` for write queries (INSERT/UPDATE/DELETE)
- Display affected rows count and last insert ID for write operations
- Add inline cell editing (double-click to edit) for SELECT results on tables with primary keys
- Add row deletion with confirmation dialog
- Add "Insert Row" dialog for adding new records
- Add `sql:allow-execute` permission for Tauri SQL plugin

## Test plan
- [ ] Run INSERT/UPDATE/DELETE queries and verify affected rows display
- [ ] Double-click cells to edit values inline
- [ ] Use row action menu to delete rows
- [ ] Click "Add Row" button to insert new records

🤖 Generated with [Claude Code](https://claude.com/claude-code)