### PR TITLE
Fix tab ordering and View Query button behavior

### DIFF
--- a/src/lib/components/explain-viewer.svelte
+++ b/src/lib/components/explain-viewer.svelte
@@ -33,10 +33,7 @@
 
   const handleViewQuery = () => {
     if (!db.activeExplainTab) return;
-    db.addQueryTab(
-      `Query`,
-      db.activeExplainTab.sourceQuery
-    );
+    db.focusOrCreateQueryTab(db.activeExplainTab.sourceQuery, 'Query');
     db.setActiveView("query");
   };
 </script>

--- a/src/lib/hooks/database.svelte.ts
+++ b/src/lib/hooks/database.svelte.ts
@@ -651,6 +651,26 @@ class UseDatabase {
     this.activeQueryTabIdByConnection = newActiveQueryIds;
   }
 
+  /**
+   * Find a query tab by its query content and focus it, or create a new one if not found.
+   * Returns the tab ID.
+   */
+  focusOrCreateQueryTab(query: string, name?: string): string | null {
+    if (!this.activeConnectionId) return null;
+
+    const tabs = this.queryTabsByConnection.get(this.activeConnectionId) || [];
+    const existingTab = tabs.find((t) => t.query.trim() === query.trim());
+
+    if (existingTab) {
+      this.setActiveQueryTab(existingTab.id);
+      this.setActiveView("query");
+      return existingTab.id;
+    }
+
+    // Create new tab if not found
+    return this.addQueryTab(name, query);
+  }
+
   updateQueryTabContent(id: string, query: string) {
     if (!this.activeConnectionId) return;
 


### PR DESCRIPTION
## Summary
- Display all tabs in unified creation order instead of grouped by type (query, schema, explain)
- View Query button on explain tabs now focuses the existing query tab instead of creating a duplicate

## Test plan
- [ ] Open multiple tabs of different types (query, schema, explain) and verify they appear in creation order
- [ ] Click "View Query" on an explain tab and verify it focuses the original query tab instead of creating a new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)