### PR TITLE
Add tab persistence across app restarts

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -155,3 +155,55 @@ export interface ExplainTab {
 	result?: ExplainResult;
 	isExecuting: boolean;
 }
+
+// Persisted state types (for storing across app restarts)
+export interface PersistedQueryTab {
+	id: string;
+	name: string;
+	query: string;
+	savedQueryId?: string;
+}
+
+export interface PersistedSchemaTab {
+	id: string;
+	tableName: string;
+	schemaName: string;
+}
+
+export interface PersistedExplainTab {
+	id: string;
+	name: string;
+	sourceQuery: string;
+}
+
+export interface PersistedSavedQuery {
+	id: string;
+	name: string;
+	query: string;
+	connectionId: string;
+	createdAt: string; // ISO string
+	updatedAt: string; // ISO string
+}
+
+export interface PersistedQueryHistoryItem {
+	id: string;
+	query: string;
+	timestamp: string; // ISO string
+	executionTime: number;
+	rowCount: number;
+	connectionId: string;
+	favorite: boolean;
+}
+
+export interface PersistedConnectionState {
+	connectionId: string;
+	queryTabs: PersistedQueryTab[];
+	schemaTabs: PersistedSchemaTab[];
+	explainTabs: PersistedExplainTab[];
+	activeQueryTabId: string | null;
+	activeSchemaTabId: string | null;
+	activeExplainTabId: string | null;
+	activeView: "query" | "schema" | "explain";
+	savedQueries: PersistedSavedQuery[];
+	queryHistory: PersistedQueryHistoryItem[];
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,17 +4,22 @@
     import { Toaster } from "$lib/components/ui/sonner/index.js";
     import AppHeader from "$lib/components/app-header.svelte";
     import * as Sidebar from "$lib/components/ui/sidebar/index.js";
-    import { setDatabase } from "$lib/hooks/database.svelte.js";
+    import { setDatabase, useDatabase } from "$lib/hooks/database.svelte.js";
     import { setShortcuts } from "$lib/shortcuts/index.js";
     import KeyboardShortcutsDialog from "$lib/components/keyboard-shortcuts-dialog.svelte";
 
     setDatabase();
+    const db = useDatabase();
     const shortcuts = setShortcuts();
 
     let { children } = $props();
+
+    function handleBeforeUnload() {
+        db.flushPersistence();
+    }
 </script>
 
-<svelte:window onkeydown={shortcuts.handleKeydown} />
+<svelte:window onkeydown={shortcuts.handleKeydown} onbeforeunload={handleBeforeUnload} />
 
 <ModeWatcher />
 <Toaster position="bottom-right" theme={"dark"} richColors />


### PR DESCRIPTION
## Summary
- Persist all tab types (query, schema, explain), saved queries, and query history across app restarts
- Use tauri-plugin-store with one file per connection (`connection_state_{connectionId}.json`)
- Debounced saves (500ms) with flush on app close via `beforeunload` handler

## Implementation
- Query tabs persist query text/name (results require re-execution)
- Schema tabs persist table/schema names (metadata refetched on connect)
- Explain tabs persist source query (results require re-execution)
- History capped at 500 items
- State cleaned up when connection is removed

## Test plan
- [ ] Create query tabs with content, close and reopen app - tabs should restore
- [ ] Open schema tabs, close and reopen app - schema tabs should restore
- [ ] Add queries to history/saved queries, close and reopen - should restore
- [ ] Remove a connection - its persisted state file should be deleted
- [ ] Close app while typing in a query tab - changes should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)