### PR TITLE
Add unsaved changes indicator and confirmation dialogs

### DIFF
--- a/src/lib/components/batch-unsaved-dialog.svelte
+++ b/src/lib/components/batch-unsaved-dialog.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import {
+		Dialog,
+		DialogContent,
+		DialogDescription,
+		DialogFooter,
+		DialogHeader,
+		DialogTitle
+	} from "$lib/components/ui/dialog";
+	import { Button } from "$lib/components/ui/button";
+
+	type Props = {
+		open?: boolean;
+		unsavedCount: number;
+		onDiscardAll: () => void;
+		onCancel: () => void;
+	};
+
+	let { open = $bindable(false), unsavedCount, onDiscardAll, onCancel }: Props = $props();
+</script>
+
+<Dialog bind:open>
+	<DialogContent class="max-w-md">
+		<DialogHeader>
+			<DialogTitle>Unsaved Changes</DialogTitle>
+			<DialogDescription>
+				{unsavedCount}
+				{unsavedCount === 1 ? "query has" : "queries have"} unsaved changes. Discard all changes?
+			</DialogDescription>
+		</DialogHeader>
+		<DialogFooter>
+			<Button
+				variant="outline"
+				onclick={() => {
+					open = false;
+					onCancel();
+				}}>Cancel</Button
+			>
+			<Button
+				variant="destructive"
+				onclick={() => {
+					open = false;
+					onDiscardAll();
+				}}>Discard All</Button
+			>
+		</DialogFooter>
+	</DialogContent>
+</Dialog>

--- a/src/lib/components/monaco-editor.svelte
+++ b/src/lib/components/monaco-editor.svelte
@@ -8,11 +8,13 @@
 		value = $bindable(""),
 		schema = [] as SchemaTable[],
 		onExecute = () => {},
+		onChange = (_value: string) => {},
 		class: className = ""
 	}: {
 		value?: string;
 		schema?: SchemaTable[];
 		onExecute?: () => void;
+		onChange?: (value: string) => void;
 		class?: string;
 	} = $props();
 
@@ -54,10 +56,12 @@
 			createSchemaCompletionProvider(() => schema)
 		);
 
-		// Sync editor content to bound value
+		// Sync editor content to bound value and notify parent
 		editor.onDidChangeModelContent(() => {
 			if (!isUpdatingFromProp && editor) {
-				value = editor.getValue();
+				const newValue = editor.getValue();
+				value = newValue;
+				onChange(newValue);
 			}
 		});
 

--- a/src/lib/components/query-editor.svelte
+++ b/src/lib/components/query-editor.svelte
@@ -333,6 +333,11 @@
                             bind:value={db.activeQueryTab.query}
                             schema={db.activeSchema}
                             onExecute={handleExecute}
+                            onChange={(newValue) => {
+                                if (db.activeQueryTabId) {
+                                    db.updateQueryTabContent(db.activeQueryTabId, newValue);
+                                }
+                            }}
                         />
                     {/key}
                 </div>

--- a/src/lib/components/save-query-dialog.svelte
+++ b/src/lib/components/save-query-dialog.svelte
@@ -6,10 +6,30 @@
 	import { Label } from "$lib/components/ui/label";
 	import { toast } from "svelte-sonner";
 
-	let { open = $bindable(false), query, tabId }: Props = $props();
+	type Props = {
+		open?: boolean;
+		query: string;
+		tabId?: string;
+		onSaveComplete?: () => void;
+	};
+
+	let { open = $bindable(false), query, tabId, onSaveComplete }: Props = $props();
 	const db = useDatabase();
 
 	let queryName = $state("");
+
+	// Pre-populate query name when dialog opens for an existing saved query
+	$effect(() => {
+		if (open && tabId) {
+			const tab = db.queryTabs.find(t => t.id === tabId);
+			if (tab?.savedQueryId) {
+				const savedQuery = db.activeConnectionSavedQueries.find(q => q.id === tab.savedQueryId);
+				if (savedQuery) {
+					queryName = savedQuery.name;
+				}
+			}
+		}
+	});
 
 	const handleSave = () => {
 		if (!queryName.trim()) {
@@ -21,18 +41,13 @@
 		toast.success("Query saved successfully");
 		open = false;
 		queryName = "";
+		onSaveComplete?.();
 	};
 
 	const handleKeydown = (e: KeyboardEvent) => {
 		if (e.key === "Enter") {
 			handleSave();
 		}
-	};
-
-	type Props = {
-		open?: boolean;
-		query: string;
-		tabId?: string;
 	};
 </script>
 

--- a/src/lib/components/unsaved-changes-dialog.svelte
+++ b/src/lib/components/unsaved-changes-dialog.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import {
+		Dialog,
+		DialogContent,
+		DialogDescription,
+		DialogFooter,
+		DialogHeader,
+		DialogTitle
+	} from "$lib/components/ui/dialog";
+	import { Button } from "$lib/components/ui/button";
+
+	type Props = {
+		open?: boolean;
+		onDiscard: () => void;
+		onSave: () => void;
+		onCancel: () => void;
+	};
+
+	let { open = $bindable(false), onDiscard, onSave, onCancel }: Props = $props();
+</script>
+
+<Dialog bind:open>
+	<DialogContent class="max-w-md">
+		<DialogHeader>
+			<DialogTitle>Unsaved Changes</DialogTitle>
+			<DialogDescription>This query has unsaved changes. What would you like to do?</DialogDescription>
+		</DialogHeader>
+		<DialogFooter class="gap-2">
+			<Button
+				variant="outline"
+				onclick={() => {
+					open = false;
+					onCancel();
+				}}>Cancel</Button
+			>
+			<Button
+				variant="destructive"
+				onclick={() => {
+					open = false;
+					onDiscard();
+				}}>Discard</Button
+			>
+			<Button
+				onclick={() => {
+					open = false;
+					onSave();
+				}}>Save</Button
+			>
+		</DialogFooter>
+	</DialogContent>
+</Dialog>


### PR DESCRIPTION
## Summary
- Display "*" indicator after tab name when a query has unsaved changes
- Show confirmation dialog when closing a tab with unsaved changes (Discard/Save/Cancel options)
- Show batch confirmation dialog for Close All/Others/Right/Left operations
- Pre-populate save dialog with existing query name when updating a saved query
- Fix reactivity issues to ensure sidebar and tab bar stay in sync when renaming queries

## Test plan
- [ ] Type in a new tab → "*" appears after tab name
- [ ] Save the query → "*" disappears
- [ ] Modify a saved query → "*" appears
- [ ] Close tab with unsaved changes → confirmation dialog appears
- [ ] Click "Discard" → tab closes without saving
- [ ] Click "Save" → save dialog opens, then tab closes after saving
- [ ] Click "Cancel" → tab remains open
- [ ] Use Cmd+W on tab with unsaved changes → same confirmation
- [ ] Right-click "Close" on tab with unsaved changes → same confirmation
- [ ] "Close All" with unsaved tabs → batch dialog appears
- [ ] Rename tab linked to saved query → sidebar updates immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)