### PR TITLE
Refactor database.svelte.ts into modular structure

### DIFF
--- a/src/lib/hooks/database/explain-tabs.svelte.ts
+++ b/src/lib/hooks/database/explain-tabs.svelte.ts
@@ -1,0 +1,44 @@
+import type { DatabaseState } from "./state.svelte.js";
+
+/**
+ * Manages explain tabs: remove, set active.
+ * Note: executeExplain is in UseDatabase as it requires database access.
+ */
+export class ExplainTabManager {
+  constructor(
+    private state: DatabaseState,
+    private schedulePersistence: (connectionId: string | null) => void,
+    private removeTabGeneric: <T extends { id: string }>(
+      tabsGetter: () => Map<string, T[]>,
+      tabsSetter: (m: Map<string, T[]>) => void,
+      activeIdGetter: () => Map<string, string | null>,
+      activeIdSetter: (m: Map<string, string | null>) => void,
+      tabId: string
+    ) => void,
+    private setActiveView: (view: "query" | "schema" | "explain") => void
+  ) {}
+
+  removeExplainTab(id: string) {
+    this.removeTabGeneric(
+      () => this.state.explainTabsByConnection,
+      (m) => (this.state.explainTabsByConnection = m),
+      () => this.state.activeExplainTabIdByConnection,
+      (m) => (this.state.activeExplainTabIdByConnection = m),
+      id
+    );
+    this.schedulePersistence(this.state.activeConnectionId);
+    // Switch to query view if no explain tabs left
+    if (this.state.activeConnectionId && this.state.explainTabs.length === 0) {
+      this.setActiveView("query");
+    }
+  }
+
+  setActiveExplainTab(id: string) {
+    if (!this.state.activeConnectionId) return;
+
+    const newActiveExplainIds = new Map(this.state.activeExplainTabIdByConnection);
+    newActiveExplainIds.set(this.state.activeConnectionId, id);
+    this.state.activeExplainTabIdByConnection = newActiveExplainIds;
+    this.schedulePersistence(this.state.activeConnectionId);
+  }
+}

--- a/src/lib/hooks/database/map-utils.ts
+++ b/src/lib/hooks/database/map-utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Helper functions for updating Map state with Svelte 5 reactivity.
+ * Maps need to be replaced with new instances to trigger reactivity.
+ */
+
+/**
+ * Set a value in a Map state while maintaining reactivity.
+ * Creates a new Map instance and calls the setter.
+ */
+export function setMapValue<K, V>(
+  getter: () => Map<K, V>,
+  setter: (m: Map<K, V>) => void,
+  key: K,
+  value: V
+): void {
+  const newMap = new Map(getter());
+  newMap.set(key, value);
+  setter(newMap);
+}
+
+/**
+ * Delete a key from a Map state while maintaining reactivity.
+ * Creates a new Map instance and calls the setter.
+ */
+export function deleteMapKey<K, V>(
+  getter: () => Map<K, V>,
+  setter: (m: Map<K, V>) => void,
+  key: K
+): void {
+  const newMap = new Map(getter());
+  newMap.delete(key);
+  setter(newMap);
+}

--- a/src/lib/hooks/database/query-history.svelte.ts
+++ b/src/lib/hooks/database/query-history.svelte.ts
@@ -1,0 +1,55 @@
+import type { QueryResult, QueryHistoryItem } from "$lib/types";
+import type { DatabaseState } from "./state.svelte.js";
+
+/**
+ * Manages query history: adding entries, toggling favorites.
+ * Note: loadQueryFromHistory is in UseDatabase as it orchestrates multiple services.
+ */
+export class QueryHistoryManager {
+  constructor(
+    private state: DatabaseState,
+    private schedulePersistence: (connectionId: string | null) => void
+  ) {}
+
+  /**
+   * Add a query to the history for the active connection.
+   */
+  addToHistory(query: string, results: QueryResult) {
+    if (!this.state.activeConnectionId) return;
+
+    const queryHistory = this.state.queryHistoryByConnection.get(this.state.activeConnectionId) || [];
+    const newQueryHistory = new Map(this.state.queryHistoryByConnection);
+    newQueryHistory.set(this.state.activeConnectionId, [
+      {
+        id: `hist-${Date.now()}`,
+        query,
+        timestamp: new Date(),
+        executionTime: results.executionTime,
+        rowCount: results.affectedRows ?? results.totalRows,
+        connectionId: this.state.activeConnectionId,
+        favorite: false,
+      },
+      ...queryHistory,
+    ]);
+    this.state.queryHistoryByConnection = newQueryHistory;
+    this.schedulePersistence(this.state.activeConnectionId);
+  }
+
+  /**
+   * Toggle the favorite status of a history item.
+   */
+  toggleQueryFavorite(id: string) {
+    if (!this.state.activeConnectionId) return;
+
+    const queryHistory =
+      this.state.queryHistoryByConnection.get(this.state.activeConnectionId) || [];
+    const item = queryHistory.find((h: QueryHistoryItem) => h.id === id);
+    if (item) {
+      item.favorite = !item.favorite;
+      const newQueryHistory = new Map(this.state.queryHistoryByConnection);
+      newQueryHistory.set(this.state.activeConnectionId, [...queryHistory]);
+      this.state.queryHistoryByConnection = newQueryHistory;
+      this.schedulePersistence(this.state.activeConnectionId);
+    }
+  }
+}

--- a/src/lib/hooks/database/query-tabs.svelte.ts
+++ b/src/lib/hooks/database/query-tabs.svelte.ts
@@ -1,0 +1,133 @@
+import type { QueryTab } from "$lib/types";
+import type { DatabaseState } from "./state.svelte.js";
+
+/**
+ * Manages query tabs: create, remove, rename, update content.
+ * Note: focusOrCreateQueryTab is in UseDatabase as it orchestrates with setActiveView.
+ */
+export class QueryTabManager {
+  constructor(
+    private state: DatabaseState,
+    private schedulePersistence: (connectionId: string | null) => void,
+    private removeTabGeneric: <T extends { id: string }>(
+      tabsGetter: () => Map<string, T[]>,
+      tabsSetter: (m: Map<string, T[]>) => void,
+      activeIdGetter: () => Map<string, string | null>,
+      activeIdSetter: (m: Map<string, string | null>) => void,
+      tabId: string
+    ) => void
+  ) {}
+
+  addQueryTab(name?: string, query?: string, savedQueryId?: string): string | null {
+    if (!this.state.activeConnectionId) return null;
+
+    const tabs = this.state.queryTabsByConnection.get(this.state.activeConnectionId) || [];
+    const newTab: QueryTab = $state({
+      id: `tab-${Date.now()}`,
+      name: name || `Query ${tabs.length + 1}`,
+      query: query || "",
+      isExecuting: false,
+      savedQueryId,
+    });
+
+    // Create new Map to trigger reactivity
+    const newQueryTabs = new Map(this.state.queryTabsByConnection);
+    newQueryTabs.set(this.state.activeConnectionId, [...tabs, newTab]);
+    this.state.queryTabsByConnection = newQueryTabs;
+
+    const newActiveQueryIds = new Map(this.state.activeQueryTabIdByConnection);
+    newActiveQueryIds.set(this.state.activeConnectionId, newTab.id);
+    this.state.activeQueryTabIdByConnection = newActiveQueryIds;
+
+    this.schedulePersistence(this.state.activeConnectionId);
+    return newTab.id;
+  }
+
+  removeQueryTab(id: string) {
+    this.removeTabGeneric(
+      () => this.state.queryTabsByConnection,
+      (m) => (this.state.queryTabsByConnection = m),
+      () => this.state.activeQueryTabIdByConnection,
+      (m) => (this.state.activeQueryTabIdByConnection = m),
+      id
+    );
+    this.schedulePersistence(this.state.activeConnectionId);
+  }
+
+  renameQueryTab(id: string, newName: string) {
+    if (!this.state.activeConnectionId) return;
+
+    const tabs = this.state.queryTabsByConnection.get(this.state.activeConnectionId) || [];
+    const tab = tabs.find((t) => t.id === id);
+    if (tab) {
+      // Create new array with updated tab object for proper reactivity
+      const updatedTabs = tabs.map((t) =>
+        t.id === id ? { ...t, name: newName } : t
+      );
+      const newQueryTabs = new Map(this.state.queryTabsByConnection);
+      newQueryTabs.set(this.state.activeConnectionId, updatedTabs);
+      this.state.queryTabsByConnection = newQueryTabs;
+
+      // Also update linked saved query name if exists
+      if (tab.savedQueryId) {
+        const savedQueries =
+          this.state.savedQueriesByConnection.get(this.state.activeConnectionId) || [];
+        const updatedSavedQueries = savedQueries.map((q) =>
+          q.id === tab.savedQueryId
+            ? { ...q, name: newName, updatedAt: new Date() }
+            : q
+        );
+        const newSavedQueries = new Map(this.state.savedQueriesByConnection);
+        newSavedQueries.set(this.state.activeConnectionId, updatedSavedQueries);
+        this.state.savedQueriesByConnection = newSavedQueries;
+      }
+
+      this.schedulePersistence(this.state.activeConnectionId);
+    }
+  }
+
+  setActiveQueryTab(id: string) {
+    if (!this.state.activeConnectionId) return;
+
+    const newActiveQueryIds = new Map(this.state.activeQueryTabIdByConnection);
+    newActiveQueryIds.set(this.state.activeConnectionId, id);
+    this.state.activeQueryTabIdByConnection = newActiveQueryIds;
+    this.schedulePersistence(this.state.activeConnectionId);
+  }
+
+  hasUnsavedChanges(tabId: string): boolean {
+    const tab = this.state.queryTabs.find((t) => t.id === tabId);
+    if (!tab) return false;
+
+    // Empty tabs are not considered "unsaved"
+    if (!tab.query.trim()) return false;
+
+    // Tab not linked to a saved query = unsaved
+    if (!tab.savedQueryId) return true;
+
+    // Tab linked to saved query - compare content
+    const savedQuery = this.state.activeConnectionSavedQueries.find(
+      (q) => q.id === tab.savedQueryId
+    );
+    if (!savedQuery) return true;
+
+    return tab.query !== savedQuery.query;
+  }
+
+  updateQueryTabContent(id: string, query: string) {
+    if (!this.state.activeConnectionId) return;
+
+    const tabs = this.state.queryTabsByConnection.get(this.state.activeConnectionId) || [];
+    const tab = tabs.find((t) => t.id === id);
+    if (tab && tab.query !== query) {
+      // Create new objects for proper reactivity
+      const updatedTabs = tabs.map((t) =>
+        t.id === id ? { ...t, query } : t
+      );
+      const newQueryTabs = new Map(this.state.queryTabsByConnection);
+      newQueryTabs.set(this.state.activeConnectionId, updatedTabs);
+      this.state.queryTabsByConnection = newQueryTabs;
+      this.schedulePersistence(this.state.activeConnectionId);
+    }
+  }
+}

--- a/src/lib/hooks/database/saved-queries.svelte.ts
+++ b/src/lib/hooks/database/saved-queries.svelte.ts
@@ -1,0 +1,120 @@
+import type { SavedQuery } from "$lib/types";
+import type { DatabaseState } from "./state.svelte.js";
+
+/**
+ * Manages saved queries: save, delete.
+ * Note: loadSavedQuery is in UseDatabase as it orchestrates with tabs and views.
+ */
+export class SavedQueryManager {
+  constructor(
+    private state: DatabaseState,
+    private schedulePersistence: (connectionId: string | null) => void
+  ) {}
+
+  saveQuery(name: string, query: string, tabId?: string): string | null {
+    if (!this.state.activeConnectionId) return null;
+
+    // Check if this tab is already linked to a saved query
+    let savedQueryId: string | undefined;
+    if (tabId) {
+      const tabs =
+        this.state.queryTabsByConnection.get(this.state.activeConnectionId) || [];
+      const tab = tabs.find((t) => t.id === tabId);
+      savedQueryId = tab?.savedQueryId;
+    }
+
+    if (savedQueryId) {
+      // Update existing saved query with new object for proper reactivity
+      const savedQueries =
+        this.state.savedQueriesByConnection.get(this.state.activeConnectionId) || [];
+      const savedQuery = savedQueries.find((q) => q.id === savedQueryId);
+      if (savedQuery) {
+        const updatedSavedQueries = savedQueries.map((q) =>
+          q.id === savedQueryId
+            ? { ...q, name, query, updatedAt: new Date() }
+            : q
+        );
+        const newSavedQueries = new Map(this.state.savedQueriesByConnection);
+        newSavedQueries.set(this.state.activeConnectionId, updatedSavedQueries);
+        this.state.savedQueriesByConnection = newSavedQueries;
+
+        // Also update tab name if it differs
+        if (tabId) {
+          const tabs =
+            this.state.queryTabsByConnection.get(this.state.activeConnectionId) || [];
+          const tab = tabs.find((t) => t.id === tabId);
+          if (tab && tab.name !== name) {
+            const updatedTabs = tabs.map((t) =>
+              t.id === tabId ? { ...t, name } : t
+            );
+            const newQueryTabs = new Map(this.state.queryTabsByConnection);
+            newQueryTabs.set(this.state.activeConnectionId, updatedTabs);
+            this.state.queryTabsByConnection = newQueryTabs;
+          }
+        }
+
+        this.schedulePersistence(this.state.activeConnectionId);
+        return savedQueryId;
+      }
+    }
+
+    // Create new saved query
+    const newSavedQuery: SavedQuery = {
+      id: `saved-${Date.now()}`,
+      name,
+      query,
+      connectionId: this.state.activeConnectionId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const savedQueries =
+      this.state.savedQueriesByConnection.get(this.state.activeConnectionId) || [];
+    const newSavedQueries = new Map(this.state.savedQueriesByConnection);
+    newSavedQueries.set(this.state.activeConnectionId, [
+      ...savedQueries,
+      newSavedQuery,
+    ]);
+    this.state.savedQueriesByConnection = newSavedQueries;
+
+    // Link tab to saved query if tabId provided
+    if (tabId) {
+      const tabs =
+        this.state.queryTabsByConnection.get(this.state.activeConnectionId) || [];
+      const updatedTabs = tabs.map((t) =>
+        t.id === tabId
+          ? { ...t, savedQueryId: newSavedQuery.id, name }
+          : t
+      );
+      const newQueryTabs = new Map(this.state.queryTabsByConnection);
+      newQueryTabs.set(this.state.activeConnectionId, updatedTabs);
+      this.state.queryTabsByConnection = newQueryTabs;
+    }
+
+    this.schedulePersistence(this.state.activeConnectionId);
+    return newSavedQuery.id;
+  }
+
+  deleteSavedQuery(id: string) {
+    if (!this.state.activeConnectionId) return;
+
+    const savedQueries =
+      this.state.savedQueriesByConnection.get(this.state.activeConnectionId) || [];
+    const filtered = savedQueries.filter((q) => q.id !== id);
+    const newSavedQueries = new Map(this.state.savedQueriesByConnection);
+    newSavedQueries.set(this.state.activeConnectionId, filtered);
+    this.state.savedQueriesByConnection = newSavedQueries;
+
+    // Remove savedQueryId from any tabs using this query
+    const tabs = this.state.queryTabsByConnection.get(this.state.activeConnectionId) || [];
+    tabs.forEach((tab) => {
+      if (tab.savedQueryId === id) {
+        tab.savedQueryId = undefined;
+      }
+    });
+    const newQueryTabs = new Map(this.state.queryTabsByConnection);
+    newQueryTabs.set(this.state.activeConnectionId, [...tabs]);
+    this.state.queryTabsByConnection = newQueryTabs;
+    this.schedulePersistence(this.state.activeConnectionId);
+  }
+}

--- a/src/lib/hooks/database/schema-tabs.svelte.ts
+++ b/src/lib/hooks/database/schema-tabs.svelte.ts
@@ -1,0 +1,39 @@
+import type { DatabaseState } from "./state.svelte.js";
+
+/**
+ * Manages schema tabs: remove, set active.
+ * Note: addSchemaTab is in UseDatabase as it requires database access for metadata fetching.
+ */
+export class SchemaTabManager {
+  constructor(
+    private state: DatabaseState,
+    private schedulePersistence: (connectionId: string | null) => void,
+    private removeTabGeneric: <T extends { id: string }>(
+      tabsGetter: () => Map<string, T[]>,
+      tabsSetter: (m: Map<string, T[]>) => void,
+      activeIdGetter: () => Map<string, string | null>,
+      activeIdSetter: (m: Map<string, string | null>) => void,
+      tabId: string
+    ) => void
+  ) {}
+
+  removeSchemaTab(id: string) {
+    this.removeTabGeneric(
+      () => this.state.schemaTabsByConnection,
+      (m) => (this.state.schemaTabsByConnection = m),
+      () => this.state.activeSchemaTabIdByConnection,
+      (m) => (this.state.activeSchemaTabIdByConnection = m),
+      id
+    );
+    this.schedulePersistence(this.state.activeConnectionId);
+  }
+
+  setActiveSchemaTab(id: string) {
+    if (!this.state.activeConnectionId) return;
+
+    const newActiveSchemaIds = new Map(this.state.activeSchemaTabIdByConnection);
+    newActiveSchemaIds.set(this.state.activeConnectionId, id);
+    this.state.activeSchemaTabIdByConnection = newActiveSchemaIds;
+    this.schedulePersistence(this.state.activeConnectionId);
+  }
+}

--- a/src/lib/hooks/database/state.svelte.ts
+++ b/src/lib/hooks/database/state.svelte.ts
@@ -1,0 +1,128 @@
+import type {
+  DatabaseConnection,
+  SchemaTable,
+  QueryTab,
+  QueryHistoryItem,
+  AIMessage,
+  SchemaTab,
+  SavedQuery,
+  ExplainTab,
+} from "$lib/types";
+
+/**
+ * Central state container for the database module.
+ * All reactive state and derived values are declared here.
+ * Modules receive this instance and read/write state through it.
+ */
+export class DatabaseState {
+  // Core state
+  connections = $state<DatabaseConnection[]>([]);
+  activeConnectionId = $state<string | null>(null);
+  schemas = $state<Map<string, SchemaTable[]>>(new Map());
+
+  // Query tabs state
+  queryTabsByConnection = $state<Map<string, QueryTab[]>>(new Map());
+  activeQueryTabIdByConnection = $state<Map<string, string | null>>(new Map());
+
+  // Schema tabs state
+  schemaTabsByConnection = $state<Map<string, SchemaTab[]>>(new Map());
+  activeSchemaTabIdByConnection = $state<Map<string, string | null>>(new Map());
+
+  // Query history and saved queries
+  queryHistoryByConnection = $state<Map<string, QueryHistoryItem[]>>(new Map());
+  savedQueriesByConnection = $state<Map<string, SavedQuery[]>>(new Map());
+
+  // Explain tabs state
+  explainTabsByConnection = $state<Map<string, ExplainTab[]>>(new Map());
+  activeExplainTabIdByConnection = $state<Map<string, string | null>>(new Map());
+
+  // AI state
+  aiMessages = $state<AIMessage[]>([]);
+  isAIOpen = $state(false);
+
+  // View state
+  activeView = $state<"query" | "schema" | "explain">("query");
+
+  // Derived: active connection object
+  activeConnection = $derived(
+    this.connections.find((c) => c.id === this.activeConnectionId) || null,
+  );
+
+  // Derived: query tabs for active connection
+  queryTabs = $derived(
+    this.activeConnectionId
+      ? this.queryTabsByConnection.get(this.activeConnectionId) || []
+      : [],
+  );
+
+  // Derived: active query tab ID for active connection
+  activeQueryTabId = $derived(
+    this.activeConnectionId
+      ? this.activeQueryTabIdByConnection.get(this.activeConnectionId) || null
+      : null,
+  );
+
+  // Derived: active query tab object
+  activeQueryTab = $derived(
+    this.queryTabs.find((t) => t.id === this.activeQueryTabId) || null,
+  );
+
+  // Derived: schema tabs for active connection
+  schemaTabs = $derived(
+    this.activeConnectionId
+      ? this.schemaTabsByConnection.get(this.activeConnectionId) || []
+      : [],
+  );
+
+  // Derived: active schema tab ID for active connection
+  activeSchemaTabId = $derived(
+    this.activeConnectionId
+      ? this.activeSchemaTabIdByConnection.get(this.activeConnectionId) || null
+      : null,
+  );
+
+  // Derived: active schema tab object
+  activeSchemaTab = $derived(
+    this.schemaTabs.find((t) => t.id === this.activeSchemaTabId) || null,
+  );
+
+  // Derived: schema for active connection
+  activeSchema = $derived(
+    this.activeConnectionId
+      ? this.schemas.get(this.activeConnectionId) || []
+      : [],
+  );
+
+  // Derived: query history for active connection
+  activeConnectionQueryHistory = $derived(
+    this.activeConnectionId
+      ? this.queryHistoryByConnection.get(this.activeConnectionId) || []
+      : [],
+  );
+
+  // Derived: saved queries for active connection
+  activeConnectionSavedQueries = $derived(
+    this.activeConnectionId
+      ? this.savedQueriesByConnection.get(this.activeConnectionId) || []
+      : [],
+  );
+
+  // Derived: explain tabs for active connection
+  explainTabs = $derived(
+    this.activeConnectionId
+      ? this.explainTabsByConnection.get(this.activeConnectionId) || []
+      : [],
+  );
+
+  // Derived: active explain tab ID for active connection
+  activeExplainTabId = $derived(
+    this.activeConnectionId
+      ? this.activeExplainTabIdByConnection.get(this.activeConnectionId) || null
+      : null,
+  );
+
+  // Derived: active explain tab object
+  activeExplainTab = $derived(
+    this.explainTabs.find((t) => t.id === this.activeExplainTabId) || null,
+  );
+}

--- a/src/lib/hooks/database/types.ts
+++ b/src/lib/hooks/database/types.ts
@@ -1,0 +1,16 @@
+import type { DatabaseConnection, SSHTunnelConfig } from "$lib/types";
+
+// Type for persisted connection data (without password and database instance)
+export interface PersistedConnection {
+  id: string;
+  name: string;
+  type: DatabaseConnection["type"];
+  host: string;
+  port: number;
+  databaseName: string;
+  username: string;
+  sslMode?: string;
+  connectionString?: string;
+  lastConnected?: Date;
+  sshTunnel?: SSHTunnelConfig;
+}

--- a/src/lib/hooks/database/ui-state.svelte.ts
+++ b/src/lib/hooks/database/ui-state.svelte.ts
@@ -1,0 +1,46 @@
+import type { AIMessage } from "$lib/types";
+import type { DatabaseState } from "./state.svelte.js";
+
+/**
+ * Manages UI state: AI panel, view switching.
+ */
+export class UIStateManager {
+  constructor(
+    private state: DatabaseState,
+    private schedulePersistence: (connectionId: string | null) => void
+  ) {}
+
+  toggleAI() {
+    this.state.isAIOpen = !this.state.isAIOpen;
+  }
+
+  sendAIMessage(content: string) {
+    const userMessage: AIMessage = {
+      id: `msg-${Date.now()}`,
+      role: "user",
+      content,
+      timestamp: new Date(),
+    };
+    this.state.aiMessages.push(userMessage);
+
+    // Simulate AI response
+    setTimeout(() => {
+      const responses = [
+        "Hey, it's Mike. I appreciate your enthusiasm to play with the AI integration. It's not quite ready yet (boo), but rest assured this is a key feature that is high on my roadmap.",
+      ];
+
+      const assistantMessage: AIMessage = {
+        id: `msg-${Date.now()}`,
+        role: "assistant",
+        content: responses[Math.floor(Math.random() * responses.length)],
+        timestamp: new Date(),
+      };
+      this.state.aiMessages.push(assistantMessage);
+    }, 1000);
+  }
+
+  setActiveView(view: "query" | "schema" | "explain") {
+    this.state.activeView = view;
+    this.schedulePersistence(this.state.activeConnectionId);
+  }
+}


### PR DESCRIPTION
## Summary
- Split monolithic 1761-line UseDatabase class into 9 focused modules
- Main file reduced to 1413 lines (~20% reduction)
- Uses facade pattern - identical external API maintained

## New Module Structure
```
src/lib/hooks/database/
  types.ts               - PersistedConnection type
  map-utils.ts           - Reactive Map helpers
  state.svelte.ts        - All $state/$derived declarations
  ui-state.svelte.ts     - AI panel, view switching
  query-history.svelte.ts - History tracking
  query-tabs.svelte.ts   - Query tab CRUD
  saved-queries.svelte.ts - Save/load queries
  schema-tabs.svelte.ts  - Schema tab management
  explain-tabs.svelte.ts - Explain tab management
```

## Test plan
- [x] Type checking passes (`npm run check`)
- [ ] Manual testing of query execution
- [ ] Manual testing of tab management
- [ ] Manual testing of saved queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)