### PR TITLE
Add Entity Relationship Diagram (ERD) viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@dagrejs/dagre": "^1.1.8",
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-dialog": "^2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.4",
         "@tauri-apps/plugin-os": "^2.3.2",
@@ -18,6 +19,7 @@
         "@tauri-apps/plugin-store": "^2.4.1",
         "@tauri-apps/plugin-updater": "^2.9.0",
         "@xyflow/svelte": "^1.5.0",
+        "html-to-image": "^1.11.13",
         "monaco-editor": "^0.55.1",
         "monaco-sql-languages": "^0.15.1",
         "sql-formatter": "^15.6.12"
@@ -1603,6 +1605,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tauri-apps/plugin-clipboard-manager": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.2.tgz",
+      "integrity": "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
     "node_modules/@tauri-apps/plugin-dialog": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.4.2.tgz",
@@ -1742,7 +1753,6 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2430,6 +2440,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@dagrejs/dagre": "^1.1.8",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.4.2",
     "@tauri-apps/plugin-fs": "^2.4.4",
     "@tauri-apps/plugin-os": "^2.3.2",
@@ -25,6 +26,7 @@
     "@tauri-apps/plugin-store": "^2.4.1",
     "@tauri-apps/plugin-updater": "^2.9.0",
     "@xyflow/svelte": "^1.5.0",
+    "html-to-image": "^1.11.13",
     "monaco-editor": "^0.55.1",
     "monaco-sql-languages": "^0.15.1",
     "sql-formatter": "^15.6.12"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,6 +66,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +126,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2 0.6.3",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -210,6 +275,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.17",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +353,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +371,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
 ]
 
 [[package]]
@@ -327,6 +450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +472,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -436,6 +571,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -512,6 +649,21 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -615,6 +767,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +813,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1138,6 +1318,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1363,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
@@ -1197,10 +1403,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "fdeflate"
@@ -1254,6 +1495,12 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1637,6 +1884,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +2050,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2028,7 +2296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -2140,6 +2408,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.0",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core 0.5.0",
+ "zune-jpeg 0.5.8",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,6 +2490,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,6 +2514,15 @@ checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2247,6 +2575,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2313,6 +2651,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2685,16 @@ name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -2408,6 +2762,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,6 +2812,16 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
 
 [[package]]
 name = "md-5"
@@ -2515,6 +2888,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,7 +2912,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.17",
  "windows-sys 0.60.2",
@@ -2591,6 +2974,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,6 +3022,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +3048,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3036,6 +3456,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3587,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,6 +3622,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.12.1",
+]
 
 [[package]]
 name = "phf"
@@ -3398,6 +3851,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,6 +3992,49 @@ checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3726,10 +4235,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.17",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -3875,6 +4454,12 @@ dependencies = [
  "web-sys",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "ring"
@@ -4227,13 +4812,16 @@ dependencies = [
 name = "seaquel"
 version = "0.2.0"
 dependencies = [
+ "arboard",
  "async-trait",
+ "image",
  "russh",
  "russh-keys",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-os",
@@ -4514,6 +5102,15 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "siphasher"
@@ -5152,7 +5749,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -5197,6 +5794,21 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.8",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5487,6 +6099,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -5806,10 +6432,21 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.17",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -5976,6 +6613,17 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -6173,6 +6821,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-scanner"
 version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6311,6 +6972,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -6921,6 +7588,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.17",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6993,6 +7678,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7001,6 +7703,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
@@ -7171,6 +7879,45 @@ dependencies = [
  "crc32fast",
  "indexmap 2.12.1",
  "memchr",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111f7d9820f05fd715df3144e254d6fc02ee4088b0644c0ffd0efc9e6d9d2773"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35aee689668bf9bd6f6f3a6c60bb29ba1244b3b43adfd50edd554a371da37d5"
+dependencies = [
+ "zune-core 0.5.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,9 @@ russh-keys = "0.48"
 async-trait = "0.1"
 tokio = { version = "1", features = ["sync", "net", "io-util"] }
 tauri-plugin-os = "2"
+tauri-plugin-clipboard-manager = "2.3.2"
+arboard = "3.6.1"
+image = "0.25.9"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -16,6 +16,12 @@
     "store:default",
     "dialog:default",
     "fs:allow-write-text-file",
-    "os:default"
+    "fs:allow-write-file",
+    "fs:allow-temp-write",
+    "fs:allow-remove",
+    "core:path:default",
+    "os:default",
+    "clipboard-manager:allow-write-image",
+    "clipboard-manager:allow-write-text"
   ]
 }

--- a/src/lib/components/app-header.svelte
+++ b/src/lib/components/app-header.svelte
@@ -9,6 +9,7 @@
     import XIcon from "@lucide/svelte/icons/x";
     import PlusIcon from "@lucide/svelte/icons/plus";
     import BotIcon from "@lucide/svelte/icons/bot";
+    import NetworkIcon from "@lucide/svelte/icons/network";
     import ThemeToggle from "./theme-toggle.svelte";
     import type { DatabaseType } from "$lib/types";
 
@@ -142,6 +143,17 @@
             {/if}
         </div>
         <div class="flex items-center gap-1">
+            {#if db.activeConnection?.database}
+                <Button
+                    size="icon"
+                    variant="ghost"
+                    class="size-8"
+                    title="View ERD"
+                    onclick={() => db.addErdTab()}
+                >
+                    <NetworkIcon class="size-5" />
+                </Button>
+            {/if}
             <Button
                 size="icon"
                 variant="ghost"

--- a/src/lib/components/erd-table-node.svelte
+++ b/src/lib/components/erd-table-node.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+  import { Handle, Position } from "@xyflow/svelte";
+  import type { SchemaTable } from "$lib/types";
+  import KeyIcon from "@lucide/svelte/icons/key";
+  import LinkIcon from "@lucide/svelte/icons/link";
+
+  interface Props {
+    data: {
+      table: SchemaTable;
+      width: number;
+      height: number;
+    };
+    isConnectable: boolean;
+  }
+
+  let { data, isConnectable }: Props = $props();
+
+  // Abbreviate data types for display
+  const abbreviateType = (type: string): string => {
+    const abbrevMap: Record<string, string> = {
+      "character varying": "varchar",
+      "timestamp without time zone": "timestamp",
+      "timestamp with time zone": "timestamptz",
+      "double precision": "double",
+      "boolean": "bool",
+      "integer": "int",
+      "bigint": "bigint",
+      "smallint": "smallint",
+      "text": "text",
+      "uuid": "uuid",
+      "json": "json",
+      "jsonb": "jsonb",
+      "bytea": "bytea",
+      "date": "date",
+      "time": "time",
+      "numeric": "numeric",
+      "real": "real",
+      "serial": "serial",
+      "bigserial": "bigserial",
+    };
+
+    const lowerType = type.toLowerCase();
+    for (const [full, abbrev] of Object.entries(abbrevMap)) {
+      if (lowerType.startsWith(full)) {
+        return abbrev;
+      }
+    }
+
+    // Truncate long types
+    if (type.length > 12) {
+      return type.substring(0, 10) + "...";
+    }
+    return type;
+  };
+
+  const maxVisibleColumns = 15;
+  const visibleColumns = $derived(data.table.columns.slice(0, maxVisibleColumns));
+  const hiddenCount = $derived(data.table.columns.length - maxVisibleColumns);
+</script>
+
+<div
+  class="bg-card border-2 border-border rounded-lg shadow-md overflow-hidden relative"
+  style="width: {data.width}px;"
+>
+  <!-- Hidden handles for edge connections -->
+  <Handle
+    type="target"
+    position={Position.Left}
+    {isConnectable}
+    class="!opacity-0 !w-0 !h-0"
+  />
+  <Handle
+    type="source"
+    position={Position.Right}
+    {isConnectable}
+    class="!opacity-0 !w-0 !h-0"
+  />
+
+  <!-- Table Header -->
+  <div class="bg-primary text-primary-foreground px-3 py-2 font-medium text-sm flex items-center justify-between">
+    <span class="truncate" title="{data.table.schema}.{data.table.name}">
+      {data.table.name}
+    </span>
+    <span class="text-xs opacity-70 shrink-0 ml-2">{data.table.schema}</span>
+  </div>
+
+  <!-- Columns List -->
+  <div class="text-xs divide-y divide-border">
+    {#each visibleColumns as column (column.name)}
+      <div class="px-3 py-1 flex items-center gap-2 hover:bg-muted/50">
+        <!-- Column icons -->
+        <div class="flex items-center gap-1 shrink-0 w-8">
+          {#if column.isPrimaryKey}
+            <KeyIcon class="size-3 text-amber-500" />
+          {/if}
+          {#if column.isForeignKey}
+            <LinkIcon class="size-3 text-blue-500" />
+          {/if}
+        </div>
+
+        <!-- Column name -->
+        <span class="flex-1 truncate font-mono" title={column.name}>
+          {column.name}
+        </span>
+
+        <!-- Column type -->
+        <span class="text-muted-foreground shrink-0" title={column.type}>
+          {abbreviateType(column.type)}
+        </span>
+
+        <!-- Nullable indicator -->
+        {#if column.nullable}
+          <span class="text-muted-foreground/50 shrink-0">?</span>
+        {/if}
+      </div>
+    {/each}
+
+    {#if hiddenCount > 0}
+      <div class="px-3 py-1 text-center text-muted-foreground italic">
+        +{hiddenCount} more columns
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/lib/components/erd-viewer.svelte
+++ b/src/lib/components/erd-viewer.svelte
@@ -1,0 +1,375 @@
+<script lang="ts">
+  import { useDatabase } from "$lib/hooks/database.svelte.js";
+  import { SvelteFlow, Background, Controls, MiniMap } from "@xyflow/svelte";
+  import "@xyflow/svelte/dist/style.css";
+  import { toPng } from "html-to-image";
+  import { generateErdSvg } from "$lib/utils/erd-svg-export";
+  import { toast } from "svelte-sonner";
+  import { save } from "@tauri-apps/plugin-dialog";
+  import { writeFile, writeTextFile, remove } from "@tauri-apps/plugin-fs";
+  import { tempDir } from "@tauri-apps/api/path";
+  import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+  import { invoke } from "@tauri-apps/api/core";
+  import { Input } from "$lib/components/ui/input";
+  import { Button } from "$lib/components/ui/button";
+  import { Checkbox } from "$lib/components/ui/checkbox";
+  import * as Popover from "$lib/components/ui/popover";
+  import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
+  import {
+    DatabaseIcon,
+    TableIcon,
+    LinkIcon,
+    SearchIcon,
+    FilterIcon,
+    DownloadIcon,
+    ImageIcon,
+    FileCodeIcon,
+    ClipboardIcon,
+  } from "@lucide/svelte";
+  import ErdTableNode from "./erd-table-node.svelte";
+  import { layoutErdDiagram } from "$lib/utils/erd-layout";
+  import type { Node, Edge, NodeTypes, ColorMode } from "@xyflow/svelte";
+  import { mode } from "mode-watcher";
+
+  const db = useDatabase();
+
+  // Map mode-watcher theme to xyflow colorMode
+  const colorMode: ColorMode = $derived(mode.current === "dark" ? "dark" : "light");
+
+  // Custom node types
+  const nodeTypes: NodeTypes = {
+    erdTableNode: ErdTableNode,
+  };
+
+  // Search state
+  let searchQuery = $state("");
+
+  // Schema filter state
+  const allSchemas = $derived([...new Set(db.activeSchema?.map(t => t.schema) || [])].sort());
+  let visibleSchemas = $state<Set<string>>(new Set());
+
+  // Initialize visible schemas when allSchemas changes
+  $effect(() => {
+    if (allSchemas.length > 0 && visibleSchemas.size === 0) {
+      visibleSchemas = new Set(allSchemas);
+    }
+  });
+
+  // Filtered tables based on search and schema filter
+  const filteredTables = $derived.by(() => {
+    if (!db.activeSchema) return [];
+
+    let tables = db.activeSchema;
+
+    // Apply schema filter (only if not all schemas are selected)
+    if (visibleSchemas.size > 0 && visibleSchemas.size < allSchemas.length) {
+      tables = tables.filter(t => visibleSchemas.has(t.schema));
+    }
+
+    // Apply search filter
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase();
+      tables = tables.filter(t =>
+        t.name.toLowerCase().includes(query) ||
+        t.schema.toLowerCase().includes(query)
+      );
+    }
+
+    return tables;
+  });
+
+  // Convert filtered tables to xyflow nodes and edges
+  const flowData = $derived.by(() => {
+    if (filteredTables.length === 0) {
+      return { nodes: [] as Node[], edges: [] as Edge[] };
+    }
+    return layoutErdDiagram(filteredTables);
+  });
+
+  let nodes = $derived(flowData.nodes);
+  let edges = $derived(flowData.edges);
+
+  // Calculate stats
+  const totalTableCount = $derived(db.activeSchema?.length || 0);
+  const filteredTableCount = $derived(filteredTables.length);
+  const relationshipCount = $derived(edges.length);
+  const isFiltered = $derived(filteredTableCount < totalTableCount);
+
+  // Schema toggle helper
+  const toggleSchema = (schema: string, checked: boolean | "indeterminate") => {
+    const newSet = new Set(visibleSchemas);
+    if (checked === true) {
+      newSet.add(schema);
+    } else {
+      newSet.delete(schema);
+    }
+    visibleSchemas = newSet;
+  };
+
+  const selectAllSchemas = () => {
+    visibleSchemas = new Set(allSchemas);
+  };
+
+  const clearAllSchemas = () => {
+    visibleSchemas = new Set();
+  };
+
+  // Export functionality
+  let flowContainer: HTMLElement;
+
+  const getFlowElement = () => flowContainer?.querySelector('.svelte-flow') as HTMLElement | null;
+
+  const getImageOptions = () => ({
+    backgroundColor: mode.current === 'dark' ? '#0a0a0a' : '#ffffff',
+    filter: (node: Element) => {
+      // Exclude minimap and controls from export
+      return !node.classList?.contains('svelte-flow__minimap') &&
+             !node.classList?.contains('svelte-flow__controls');
+    }
+  });
+
+  const exportToPng = async () => {
+    const element = getFlowElement();
+    if (!element) return;
+
+    try {
+      const filePath = await save({
+        defaultPath: `erd-${db.activeConnection?.name || 'diagram'}.png`,
+        filters: [{ name: 'PNG Image', extensions: ['png'] }]
+      });
+      if (!filePath) return;
+
+      const dataUrl = await toPng(element, getImageOptions());
+      const base64 = dataUrl.split(',')[1];
+      const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+      await writeFile(filePath, bytes);
+      toast.success('PNG saved');
+    } catch (e) {
+      toast.error('Failed to export PNG');
+    }
+  };
+
+  const exportToSvg = async () => {
+    try {
+      const filePath = await save({
+        defaultPath: `erd-${db.activeConnection?.name || 'diagram'}.svg`,
+        filters: [{ name: 'SVG Image', extensions: ['svg'] }]
+      });
+      if (!filePath) return;
+
+      const svg = generateErdSvg(nodes, edges, {
+        theme: mode.current === 'dark' ? 'dark' : 'light'
+      });
+      await writeTextFile(filePath, svg);
+      toast.success('SVG saved');
+    } catch (e) {
+      toast.error('Failed to export SVG');
+    }
+  };
+
+  const copyPngToClipboard = async () => {
+    const element = getFlowElement();
+    if (!element) return;
+
+    try {
+      const dataUrl = await toPng(element, getImageOptions());
+      const base64 = dataUrl.split(',')[1];
+      const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+
+      // Write to temp file, copy from there
+      const tempPath = await tempDir();
+      const filePath = `${tempPath}erd-clipboard-${Date.now()}.png`;
+      await writeFile(filePath, bytes);
+
+      await invoke('copy_image_to_clipboard', { path: filePath });
+
+      // Clean up temp file
+      await remove(filePath).catch(() => {});
+
+      toast.success('PNG copied to clipboard');
+    } catch (e) {
+      console.error('Failed to copy PNG:', e);
+      toast.error('Failed to copy PNG');
+    }
+  };
+
+  const copySvgToClipboard = async () => {
+    try {
+      const svg = generateErdSvg(nodes, edges, {
+        theme: mode.current === 'dark' ? 'dark' : 'light'
+      });
+      await writeText(svg);
+      toast.success('SVG copied to clipboard');
+    } catch (e) {
+      toast.error('Failed to copy SVG');
+    }
+  };
+</script>
+
+<div class="flex flex-col h-full">
+  {#if db.activeErdTab}
+    {#if db.activeSchema && db.activeSchema.length > 0}
+      <!-- Summary Header -->
+      <div class="p-4 border-b bg-muted/30 shrink-0">
+        <div class="flex items-start justify-between mb-3">
+          <div>
+            <h2 class="text-lg font-semibold flex items-center gap-2">
+              <DatabaseIcon class="size-5" />
+              Entity Relationship Diagram
+            </h2>
+            <div class="flex items-center gap-4 mt-1 text-sm text-muted-foreground">
+              <span class="flex items-center gap-1">
+                <TableIcon class="size-3" />
+                {#if isFiltered}
+                  {filteredTableCount} / {totalTableCount} tables
+                {:else}
+                  {totalTableCount} tables
+                {/if}
+              </span>
+              <span class="flex items-center gap-1">
+                <LinkIcon class="size-3" />
+                {relationshipCount} relationships
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Controls Row -->
+        <div class="flex items-center gap-2 flex-wrap">
+          <!-- Search Input -->
+          <div class="relative">
+            <SearchIcon class="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+            <Input
+              type="text"
+              placeholder="Search tables..."
+              class="h-8 w-48 pl-8"
+              bind:value={searchQuery}
+            />
+          </div>
+
+          <!-- Schema Filter -->
+          {#if allSchemas.length > 1}
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button variant="outline" size="sm" class="h-8">
+                  <FilterIcon class="size-4 mr-2" />
+                  Schemas ({visibleSchemas.size}/{allSchemas.length})
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content class="w-56">
+                <div class="space-y-2">
+                  <div class="flex items-center justify-between pb-2 border-b">
+                    <span class="text-sm font-medium">Filter by Schema</span>
+                    <div class="flex gap-1">
+                      <Button variant="ghost" size="sm" class="h-6 px-2 text-xs" onclick={selectAllSchemas}>
+                        All
+                      </Button>
+                      <Button variant="ghost" size="sm" class="h-6 px-2 text-xs" onclick={clearAllSchemas}>
+                        None
+                      </Button>
+                    </div>
+                  </div>
+                  {#each allSchemas as schema}
+                    <label class="flex items-center gap-2 cursor-pointer">
+                      <Checkbox
+                        checked={visibleSchemas.has(schema)}
+                        onCheckedChange={(checked: boolean | "indeterminate") => toggleSchema(schema, checked)}
+                      />
+                      <span class="text-sm">{schema}</span>
+                    </label>
+                  {/each}
+                </div>
+              </Popover.Content>
+            </Popover.Root>
+          {/if}
+
+          <!-- Export Dropdown -->
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger>
+              <Button variant="outline" size="sm" class="h-8">
+                <DownloadIcon class="size-4 mr-2" />
+                Export
+              </Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              <DropdownMenu.Label>Download</DropdownMenu.Label>
+              <DropdownMenu.Item onclick={exportToPng}>
+                <ImageIcon class="size-4 mr-2" />
+                Download PNG
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onclick={exportToSvg}>
+                <FileCodeIcon class="size-4 mr-2" />
+                Download SVG
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator />
+              <DropdownMenu.Label>Copy to Clipboard</DropdownMenu.Label>
+              <DropdownMenu.Item onclick={copyPngToClipboard}>
+                <ClipboardIcon class="size-4 mr-2" />
+                Copy as PNG
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onclick={copySvgToClipboard}>
+                <ClipboardIcon class="size-4 mr-2" />
+                Copy as SVG
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </div>
+      </div>
+
+      <!-- Flow Diagram -->
+      <div class="flex-1 min-h-0" bind:this={flowContainer}>
+        {#if filteredTables.length > 0}
+          <SvelteFlow
+            {nodes}
+            {edges}
+            {nodeTypes}
+            {colorMode}
+            fitView
+            minZoom={0.1}
+            maxZoom={2}
+            nodesDraggable={true}
+            nodesConnectable={false}
+            elementsSelectable={true}
+            deleteKey={null}
+            proOptions={{ hideAttribution: true }}
+          >
+            <Background />
+            <Controls />
+            <MiniMap />
+          </SvelteFlow>
+        {:else}
+          <div class="h-full flex items-center justify-center text-muted-foreground">
+            <div class="text-center">
+              <SearchIcon class="size-12 mx-auto mb-2 opacity-20" />
+              <p class="text-sm">No tables match your filter</p>
+              <Button
+                variant="link"
+                size="sm"
+                class="mt-2"
+                onclick={() => { searchQuery = ""; visibleSchemas = new Set(allSchemas); }}
+              >
+                Clear filters
+              </Button>
+            </div>
+          </div>
+        {/if}
+      </div>
+    {:else}
+      <!-- No schema state -->
+      <div class="flex-1 flex items-center justify-center text-muted-foreground">
+        <div class="text-center">
+          <DatabaseIcon class="size-12 mx-auto mb-2 opacity-20" />
+          <p class="text-sm">No tables found in database</p>
+        </div>
+      </div>
+    {/if}
+  {:else}
+    <!-- No tab selected state -->
+    <div class="flex-1 flex items-center justify-center text-muted-foreground">
+      <div class="text-center">
+        <DatabaseIcon class="size-12 mx-auto mb-2 opacity-20" />
+        <p class="text-sm">No ERD diagram selected</p>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { Checkbox as CheckboxPrimitive } from "bits-ui";
+	import CheckIcon from "@lucide/svelte/icons/check";
+	import MinusIcon from "@lucide/svelte/icons/minus";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
+</script>
+
+<CheckboxPrimitive.Root
+	bind:ref
+	data-slot="checkbox"
+	class={cn(
+		"border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive peer flex size-4 shrink-0 items-center justify-center rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	bind:checked
+	bind:indeterminate
+	{...restProps}
+>
+	{#snippet children({ checked, indeterminate })}
+		<div data-slot="checkbox-indicator" class="text-current transition-none">
+			{#if checked}
+				<CheckIcon class="size-3.5" />
+			{:else if indeterminate}
+				<MinusIcon class="size-3.5" />
+			{/if}
+		</div>
+	{/snippet}
+</CheckboxPrimitive.Root>

--- a/src/lib/components/ui/checkbox/index.ts
+++ b/src/lib/components/ui/checkbox/index.ts
@@ -1,0 +1,6 @@
+import Root from "./checkbox.svelte";
+export {
+	Root,
+	//
+	Root as Checkbox,
+};

--- a/src/lib/components/ui/popover/index.ts
+++ b/src/lib/components/ui/popover/index.ts
@@ -1,0 +1,19 @@
+import Root from "./popover.svelte";
+import Close from "./popover-close.svelte";
+import Content from "./popover-content.svelte";
+import Trigger from "./popover-trigger.svelte";
+import Portal from "./popover-portal.svelte";
+
+export {
+	Root,
+	Content,
+	Trigger,
+	Close,
+	Portal,
+	//
+	Root as Popover,
+	Content as PopoverContent,
+	Trigger as PopoverTrigger,
+	Close as PopoverClose,
+	Portal as PopoverPortal,
+};

--- a/src/lib/components/ui/popover/popover-close.svelte
+++ b/src/lib/components/ui/popover/popover-close.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: PopoverPrimitive.CloseProps = $props();
+</script>
+
+<PopoverPrimitive.Close bind:ref data-slot="popover-close" {...restProps} />

--- a/src/lib/components/ui/popover/popover-content.svelte
+++ b/src/lib/components/ui/popover/popover-content.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from "bits-ui";
+	import PopoverPortal from "./popover-portal.svelte";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		sideOffset = 4,
+		align = "center",
+		portalProps,
+		...restProps
+	}: PopoverPrimitive.ContentProps & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof PopoverPortal>>;
+	} = $props();
+</script>
+
+<PopoverPortal {...portalProps}>
+	<PopoverPrimitive.Content
+		bind:ref
+		data-slot="popover-content"
+		{sideOffset}
+		{align}
+		class={cn(
+			"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--bits-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+			className
+		)}
+		{...restProps}
+	/>
+</PopoverPortal>

--- a/src/lib/components/ui/popover/popover-portal.svelte
+++ b/src/lib/components/ui/popover/popover-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from "bits-ui";
+
+	let { ...restProps }: PopoverPrimitive.PortalProps = $props();
+</script>
+
+<PopoverPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/popover/popover-trigger.svelte
+++ b/src/lib/components/ui/popover/popover-trigger.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { Popover as PopoverPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: PopoverPrimitive.TriggerProps = $props();
+</script>
+
+<PopoverPrimitive.Trigger
+	bind:ref
+	data-slot="popover-trigger"
+	class={cn("", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/popover/popover.svelte
+++ b/src/lib/components/ui/popover/popover.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: PopoverPrimitive.RootProps = $props();
+</script>
+
+<PopoverPrimitive.Root bind:open {...restProps} />

--- a/src/lib/hooks/database/state.svelte.ts
+++ b/src/lib/hooks/database/state.svelte.ts
@@ -7,6 +7,7 @@ import type {
   SchemaTab,
   SavedQuery,
   ExplainTab,
+  ErdTab,
 } from "$lib/types";
 
 /**
@@ -36,12 +37,16 @@ export class DatabaseState {
   explainTabsByConnection = $state<Map<string, ExplainTab[]>>(new Map());
   activeExplainTabIdByConnection = $state<Map<string, string | null>>(new Map());
 
+  // ERD tabs state
+  erdTabsByConnection = $state<Map<string, ErdTab[]>>(new Map());
+  activeErdTabIdByConnection = $state<Map<string, string | null>>(new Map());
+
   // AI state
   aiMessages = $state<AIMessage[]>([]);
   isAIOpen = $state(false);
 
   // View state
-  activeView = $state<"query" | "schema" | "explain">("query");
+  activeView = $state<"query" | "schema" | "explain" | "erd">("query");
 
   // Derived: active connection object
   activeConnection = $derived(
@@ -124,5 +129,24 @@ export class DatabaseState {
   // Derived: active explain tab object
   activeExplainTab = $derived(
     this.explainTabs.find((t) => t.id === this.activeExplainTabId) || null,
+  );
+
+  // Derived: ERD tabs for active connection
+  erdTabs = $derived(
+    this.activeConnectionId
+      ? this.erdTabsByConnection.get(this.activeConnectionId) || []
+      : [],
+  );
+
+  // Derived: active ERD tab ID for active connection
+  activeErdTabId = $derived(
+    this.activeConnectionId
+      ? this.activeErdTabIdByConnection.get(this.activeConnectionId) || null
+      : null,
+  );
+
+  // Derived: active ERD tab object
+  activeErdTab = $derived(
+    this.erdTabs.find((t) => t.id === this.activeErdTabId) || null,
   );
 }

--- a/src/lib/hooks/database/ui-state.svelte.ts
+++ b/src/lib/hooks/database/ui-state.svelte.ts
@@ -39,7 +39,7 @@ export class UIStateManager {
     }, 1000);
   }
 
-  setActiveView(view: "query" | "schema" | "explain") {
+  setActiveView(view: "query" | "schema" | "explain" | "erd") {
     this.state.activeView = view;
     this.schedulePersistence(this.state.activeConnectionId);
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,12 @@ export interface SchemaTable {
 	indexes: SchemaIndex[];
 }
 
+export interface ForeignKeyRef {
+	referencedSchema: string;
+	referencedTable: string;
+	referencedColumn: string;
+}
+
 export interface SchemaColumn {
 	name: string;
 	type: string;
@@ -46,7 +52,7 @@ export interface SchemaColumn {
 	defaultValue?: string;
 	isPrimaryKey: boolean;
 	isForeignKey: boolean;
-	foreignKeyRef?: string;
+	foreignKeyRef?: ForeignKeyRef;
 }
 
 export interface SchemaIndex {
@@ -156,6 +162,12 @@ export interface ExplainTab {
 	isExecuting: boolean;
 }
 
+// ERD types
+export interface ErdTab {
+	id: string;
+	name: string;
+}
+
 // Persisted state types (for storing across app restarts)
 export interface PersistedQueryTab {
 	id: string;
@@ -174,6 +186,11 @@ export interface PersistedExplainTab {
 	id: string;
 	name: string;
 	sourceQuery: string;
+}
+
+export interface PersistedErdTab {
+	id: string;
+	name: string;
 }
 
 export interface PersistedSavedQuery {
@@ -200,10 +217,12 @@ export interface PersistedConnectionState {
 	queryTabs: PersistedQueryTab[];
 	schemaTabs: PersistedSchemaTab[];
 	explainTabs: PersistedExplainTab[];
+	erdTabs: PersistedErdTab[];
 	activeQueryTabId: string | null;
 	activeSchemaTabId: string | null;
 	activeExplainTabId: string | null;
-	activeView: "query" | "schema" | "explain";
+	activeErdTabId: string | null;
+	activeView: "query" | "schema" | "explain" | "erd";
 	savedQueries: PersistedSavedQuery[];
 	queryHistory: PersistedQueryHistoryItem[];
 }

--- a/src/lib/utils/erd-layout.ts
+++ b/src/lib/utils/erd-layout.ts
@@ -1,0 +1,114 @@
+import dagre from "@dagrejs/dagre";
+import { Position } from "@xyflow/svelte";
+import type { Node, Edge } from "@xyflow/svelte";
+import type { SchemaTable } from "$lib/types";
+
+const NODE_WIDTH = 250;
+const NODE_HEIGHT_BASE = 60; // Header height
+const COLUMN_HEIGHT = 24; // Height per column row
+
+/**
+ * Calculates the height of a table node based on the number of columns.
+ * Caps at a maximum height to prevent overly tall nodes.
+ */
+function calculateNodeHeight(columnCount: number): number {
+  const maxVisibleColumns = 15;
+  const visibleColumns = Math.min(columnCount, maxVisibleColumns);
+  return NODE_HEIGHT_BASE + (visibleColumns * COLUMN_HEIGHT);
+}
+
+/**
+ * Converts schema tables to xyflow nodes and edges for ERD visualization.
+ * Uses Dagre for automatic graph layout.
+ */
+export function layoutErdDiagram(tables: SchemaTable[]): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  // Create a map for quick table lookup by schema.name
+  const tableMap = new Map<string, SchemaTable>();
+  for (const table of tables) {
+    const key = `${table.schema}.${table.name}`;
+    tableMap.set(key, table);
+  }
+
+  // Create nodes for each table
+  for (const table of tables) {
+    const nodeId = `${table.schema}.${table.name}`;
+    const nodeHeight = calculateNodeHeight(table.columns.length);
+
+    nodes.push({
+      id: nodeId,
+      type: "erdTableNode",
+      position: { x: 0, y: 0 }, // Will be set by dagre
+      data: {
+        table,
+        width: NODE_WIDTH,
+        height: nodeHeight,
+      },
+    });
+
+    // Create edges for foreign key relationships
+    for (const column of table.columns) {
+      if (column.isForeignKey && column.foreignKeyRef) {
+        const targetKey = `${column.foreignKeyRef.referencedSchema}.${column.foreignKeyRef.referencedTable}`;
+
+        // Only create edge if target table exists in our schema
+        if (tableMap.has(targetKey)) {
+          edges.push({
+            id: `edge-${nodeId}-${column.name}-${targetKey}`,
+            source: nodeId,
+            target: targetKey,
+            type: "smoothstep",
+            animated: false,
+            style: "stroke-width: 2px; stroke: #737373;",
+            label: `${column.name} → ${column.foreignKeyRef.referencedColumn}`,
+            labelStyle: "font-size: 10px; fill: #737373;",
+          });
+        }
+      }
+    }
+  }
+
+  // Use dagre for layout
+  const dagreGraph = new dagre.graphlib.Graph();
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setGraph({
+    rankdir: "LR", // Left to right for ERD
+    nodesep: 80,   // Horizontal separation
+    ranksep: 120,  // Vertical separation
+    marginx: 40,
+    marginy: 40,
+  });
+
+  // Add nodes to dagre with their calculated heights
+  for (const node of nodes) {
+    const height = (node.data as { height: number }).height;
+    dagreGraph.setNode(node.id, { width: NODE_WIDTH, height });
+  }
+
+  // Add edges to dagre
+  for (const edge of edges) {
+    dagreGraph.setEdge(edge.source, edge.target);
+  }
+
+  // Calculate layout
+  dagre.layout(dagreGraph);
+
+  // Apply positions from dagre
+  const layoutedNodes = nodes.map((node) => {
+    const nodeWithPosition = dagreGraph.node(node.id);
+    const height = (node.data as { height: number }).height;
+    return {
+      ...node,
+      targetPosition: Position.Left,
+      sourcePosition: Position.Right,
+      position: {
+        x: nodeWithPosition.x - NODE_WIDTH / 2,
+        y: nodeWithPosition.y - height / 2,
+      },
+    };
+  });
+
+  return { nodes: layoutedNodes, edges };
+}

--- a/src/lib/utils/erd-svg-export.ts
+++ b/src/lib/utils/erd-svg-export.ts
@@ -1,0 +1,246 @@
+import type { Node, Edge } from "@xyflow/svelte";
+import type { SchemaTable } from "$lib/types";
+
+interface SvgExportOptions {
+  theme: "light" | "dark";
+  padding?: number;
+}
+
+interface ThemeColors {
+  background: string;
+  headerBg: string;
+  headerText: string;
+  bodyBg: string;
+  bodyBorder: string;
+  columnText: string;
+  mutedText: string;
+  edgeStroke: string;
+  pkColor: string;
+  fkColor: string;
+}
+
+const THEMES: Record<"light" | "dark", ThemeColors> = {
+  light: {
+    background: "#ffffff",
+    headerBg: "#171717",
+    headerText: "#fafafa",
+    bodyBg: "#ffffff",
+    bodyBorder: "#e5e5e5",
+    columnText: "#171717",
+    mutedText: "#737373",
+    edgeStroke: "#a3a3a3",
+    pkColor: "#f59e0b",
+    fkColor: "#3b82f6",
+  },
+  dark: {
+    background: "#0a0a0a",
+    headerBg: "#fafafa",
+    headerText: "#171717",
+    bodyBg: "#0a0a0a",
+    bodyBorder: "#262626",
+    columnText: "#fafafa",
+    mutedText: "#a3a3a3",
+    edgeStroke: "#525252",
+    pkColor: "#f59e0b",
+    fkColor: "#3b82f6",
+  },
+};
+
+const NODE_WIDTH = 250;
+const HEADER_HEIGHT = 32;
+const COLUMN_HEIGHT = 24;
+const MAX_VISIBLE_COLUMNS = 15;
+const FONT_FAMILY = "system-ui, -apple-system, sans-serif";
+const MONO_FONT = "ui-monospace, monospace";
+
+/**
+ * Escapes special characters for XML/SVG content.
+ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Generates a cubic bezier path for an edge (smoothstep approximation).
+ */
+function generateEdgePath(
+  sourceX: number,
+  sourceY: number,
+  targetX: number,
+  targetY: number
+): string {
+  const midX = (sourceX + targetX) / 2;
+  return `M ${sourceX} ${sourceY} C ${midX} ${sourceY}, ${midX} ${targetY}, ${targetX} ${targetY}`;
+}
+
+/**
+ * Abbreviates data types for display (mirrors erd-table-node.svelte logic).
+ */
+function abbreviateType(type: string): string {
+  const abbrevMap: Record<string, string> = {
+    "character varying": "varchar",
+    "timestamp without time zone": "timestamp",
+    "timestamp with time zone": "timestamptz",
+    "double precision": "double",
+    boolean: "bool",
+    integer: "int",
+  };
+
+  const lowerType = type.toLowerCase();
+  for (const [full, abbrev] of Object.entries(abbrevMap)) {
+    if (lowerType.startsWith(full)) {
+      return abbrev;
+    }
+  }
+
+  if (type.length > 12) {
+    return type.substring(0, 10) + "...";
+  }
+  return type;
+}
+
+/**
+ * Generates a clean, lightweight SVG string from ERD nodes and edges.
+ */
+export function generateErdSvg(
+  nodes: Node[],
+  edges: Edge[],
+  options: SvgExportOptions
+): string {
+  const { theme, padding = 40 } = options;
+  const colors = THEMES[theme];
+
+  // Calculate bounding box
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity;
+
+  for (const node of nodes) {
+    const { x, y } = node.position;
+    const data = node.data as { table: SchemaTable; width: number; height: number };
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x + data.width);
+    maxY = Math.max(maxY, y + data.height);
+  }
+
+  // Handle empty case
+  if (nodes.length === 0) {
+    return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text x="50" y="50" text-anchor="middle">No tables</text></svg>`;
+  }
+
+  const width = maxX - minX + padding * 2;
+  const height = maxY - minY + padding * 2;
+  const offsetX = -minX + padding;
+  const offsetY = -minY + padding;
+
+  // Build node lookup for edge calculations
+  const nodeMap = new Map<string, { x: number; y: number; height: number }>();
+  for (const node of nodes) {
+    const data = node.data as { table: SchemaTable; height: number };
+    nodeMap.set(node.id, {
+      x: node.position.x + offsetX,
+      y: node.position.y + offsetY,
+      height: data.height,
+    });
+  }
+
+  // Generate edges SVG
+  const edgesSvg = edges
+    .map((edge) => {
+      const source = nodeMap.get(edge.source);
+      const target = nodeMap.get(edge.target);
+      if (!source || !target) return "";
+
+      const sourceX = source.x + NODE_WIDTH;
+      const sourceY = source.y + source.height / 2;
+      const targetX = target.x;
+      const targetY = target.y + target.height / 2;
+
+      const path = generateEdgePath(sourceX, sourceY, targetX, targetY);
+      return `<path d="${path}" fill="none" stroke="${colors.edgeStroke}" stroke-width="2"/>`;
+    })
+    .join("\n    ");
+
+  // Generate nodes SVG
+  const nodesSvg = nodes
+    .map((node) => {
+      const data = node.data as { table: SchemaTable; width: number; height: number };
+      const { table } = data;
+      const x = node.position.x + offsetX;
+      const y = node.position.y + offsetY;
+
+      const visibleColumns = table.columns.slice(0, MAX_VISIBLE_COLUMNS);
+      const hiddenCount = table.columns.length - MAX_VISIBLE_COLUMNS;
+      const bodyHeight = data.height - HEADER_HEIGHT;
+
+      // Column rows
+      const columnRows = visibleColumns
+        .map((col, i) => {
+          const colY = HEADER_HEIGHT + 4 + i * COLUMN_HEIGHT + 16;
+          const icons: string[] = [];
+          let iconOffset = 8;
+
+          if (col.isPrimaryKey) {
+            icons.push(
+              `<text x="${iconOffset}" y="${colY}" fill="${colors.pkColor}" font-size="10">PK</text>`
+            );
+            iconOffset += 20;
+          }
+          if (col.isForeignKey) {
+            icons.push(
+              `<text x="${iconOffset}" y="${colY}" fill="${colors.fkColor}" font-size="10">FK</text>`
+            );
+            iconOffset += 20;
+          }
+
+          const nameX = 40;
+          const typeX = NODE_WIDTH - 8;
+          const nullable = col.nullable ? "?" : "";
+
+          return `
+      ${icons.join("")}
+      <text x="${nameX}" y="${colY}" fill="${colors.columnText}" font-family="${MONO_FONT}" font-size="11">${escapeXml(col.name)}</text>
+      <text x="${typeX}" y="${colY}" fill="${colors.mutedText}" font-family="${MONO_FONT}" font-size="11" text-anchor="end">${escapeXml(abbreviateType(col.type))}${nullable}</text>`;
+        })
+        .join("");
+
+      // Hidden count row
+      const hiddenRow =
+        hiddenCount > 0
+          ? `<text x="${NODE_WIDTH / 2}" y="${HEADER_HEIGHT + visibleColumns.length * COLUMN_HEIGHT + 20}" fill="${colors.mutedText}" font-size="11" text-anchor="middle" font-style="italic">+${hiddenCount} more columns</text>`
+          : "";
+
+      return `
+  <g transform="translate(${x}, ${y})">
+    <!-- Table box -->
+    <rect x="0" y="0" width="${NODE_WIDTH}" height="${data.height}" rx="6" fill="${colors.bodyBg}" stroke="${colors.bodyBorder}" stroke-width="2"/>
+    <!-- Header -->
+    <rect x="0" y="0" width="${NODE_WIDTH}" height="${HEADER_HEIGHT}" rx="6" fill="${colors.headerBg}"/>
+    <rect x="0" y="${HEADER_HEIGHT - 6}" width="${NODE_WIDTH}" height="6" fill="${colors.headerBg}"/>
+    <!-- Header text -->
+    <text x="12" y="21" fill="${colors.headerText}" font-family="${FONT_FAMILY}" font-size="13" font-weight="500">${escapeXml(table.name)}</text>
+    <text x="${NODE_WIDTH - 12}" y="21" fill="${colors.headerText}" font-family="${FONT_FAMILY}" font-size="11" text-anchor="end" opacity="0.7">${escapeXml(table.schema)}</text>
+    <!-- Columns -->
+    ${columnRows}
+    ${hiddenRow}
+  </g>`;
+    })
+    .join("\n");
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">
+  <rect x="0" y="0" width="${width}" height="${height}" fill="${colors.background}"/>
+  <g>
+    ${edgesSvg}
+  </g>
+  <g>
+    ${nodesSvg}
+  </g>
+</svg>`;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,6 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import { sveltekit } from "@sveltejs/kit/vite";
 
-// @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
## Summary
- Add ERD button in header to view database schema as an interactive diagram
- Create ERD viewer with SvelteFlow and Dagre for automatic layout
- Add search/filter tables by name or schema
- Add schema filter dropdown with checkboxes
- Add export functionality (Download/Copy as PNG/SVG)
- Fix foreign key reference capture in PostgreSQL and SQLite adapters
- Add lightweight programmatic SVG generation (~10KB vs ~1.5MB)

## Test plan
- [ ] Connect to a database with foreign key relationships
- [ ] Click the ERD button (network icon) in the header
- [ ] Verify tables are displayed with columns, PK/FK indicators
- [ ] Verify relationship edges connect related tables
- [ ] Test search filtering by table name
- [ ] Test schema filter dropdown (if multiple schemas)
- [ ] Test Download PNG - should show native save dialog
- [ ] Test Download SVG - should produce lightweight file
- [ ] Test Copy as PNG - should copy to clipboard
- [ ] Test Copy as SVG - should copy SVG markup to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)