### PR TITLE
Fix tab bar horizontal scrolling

### DIFF
--- a/src/lib/components/ui/scroll-area/scroll-area.svelte
+++ b/src/lib/components/ui/scroll-area/scroll-area.svelte
@@ -29,7 +29,12 @@
 	<ScrollAreaPrimitive.Viewport
 		bind:ref={viewportRef}
 		data-slot="scroll-area-viewport"
-		class="ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-4"
+		class={cn(
+			"ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-4",
+			orientation === "horizontal" && "overflow-x-auto overflow-y-hidden",
+			orientation === "vertical" && "overflow-y-auto overflow-x-hidden",
+			orientation === "both" && "overflow-auto"
+		)}
 	>
 		{@render children?.()}
 	</ScrollAreaPrimitive.Viewport>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -269,9 +269,9 @@
 <SidebarInset class="flex flex-col h-full overflow-hidden">
     {#if db.activeConnectionId}
         <!-- Unified Tab Bar -->
-        <div class="flex items-center gap-2 p-2 border-b bg-muted/30 overflow-hidden">
-            <ScrollArea orientation="horizontal" class="flex-1">
-                <div class="flex items-center gap-1 pb-1">
+        <div class="flex items-center gap-2 p-2 border-b bg-muted/30">
+            <div class="flex-1 overflow-x-auto overflow-y-hidden min-w-0 scrollbar-hide">
+                <div class="flex items-center gap-1 w-max">
                     <!-- All tabs in creation order -->
                     {#each allTabs as { id, type, tab } (id)}
                         <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
@@ -452,7 +452,7 @@
                         {/if}
                     {/each}
                 </div>
-            </ScrollArea>
+            </div>
 
             <!-- Add new query tab button -->
             <Tooltip.Root>

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -119,3 +119,13 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Replace ScrollArea component with native CSS scrolling for the tab bar
- Add `scrollbar-hide` utility class to hide scrollbar while maintaining scroll functionality
- Add `min-w-0` to allow flex item to shrink and enable overflow scrolling

## Test plan
- [ ] Open multiple tabs until they overflow the tab bar width
- [ ] Verify horizontal scrolling works via trackpad/mouse wheel
- [ ] Verify scrollbar is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)