### PR TITLE
Add empty state screens and connection management

### DIFF
--- a/src/lib/components/empty-states/connection-card.svelte
+++ b/src/lib/components/empty-states/connection-card.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import * as Card from "$lib/components/ui/card/index.js";
+	import { Badge } from "$lib/components/ui/badge/index.js";
+	import DatabaseIcon from "@lucide/svelte/icons/database";
+	import type { DatabaseConnection } from "$lib/types";
+	import { formatRelativeTime } from "$lib/utils.js";
+	import { connectionDialogStore } from "$lib/stores/connection-dialog.svelte.js";
+	import { useDatabase } from "$lib/hooks/database.svelte.js";
+
+	interface Props {
+		connection: DatabaseConnection;
+	}
+
+	const { connection }: Props = $props();
+	const db = useDatabase();
+
+	const handleClick = () => {
+		if (connection.database) {
+			// Already connected, just activate
+			db.setActiveConnection(connection.id);
+		} else {
+			// Need to reconnect - open dialog with prefill
+			connectionDialogStore.open({
+				id: connection.id,
+				name: connection.name,
+				type: connection.type,
+				host: connection.host,
+				port: connection.port,
+				databaseName: connection.databaseName,
+				username: connection.username,
+				sslMode: connection.sslMode,
+				connectionString: connection.connectionString,
+			});
+		}
+	};
+
+	const dbTypeLabels: Record<string, string> = {
+		postgres: "PostgreSQL",
+		mysql: "MySQL",
+		mariadb: "MariaDB",
+		sqlite: "SQLite",
+		mongodb: "MongoDB",
+		mssql: "SQL Server",
+	};
+</script>
+
+<button type="button" class="text-left w-full" onclick={handleClick}>
+	<Card.Root class="hover:bg-muted/50 transition-colors cursor-pointer h-full">
+		<Card.Header class="pb-2">
+			<div class="flex items-center gap-2">
+				<span
+					class={[
+						"size-2 rounded-full shrink-0",
+						connection.database ? "bg-green-500" : "bg-gray-400",
+					]}
+					title={connection.database ? "Connected" : "Disconnected"}
+				></span>
+				<DatabaseIcon class="size-4 text-muted-foreground" />
+				<Card.Title class="text-sm font-medium truncate">{connection.name}</Card.Title>
+			</div>
+		</Card.Header>
+		<Card.Content class="pt-0 space-y-2">
+			<Badge variant="secondary" class="text-xs">
+				{dbTypeLabels[connection.type] ?? connection.type}
+			</Badge>
+			<p class="text-xs text-muted-foreground truncate">
+				{connection.host}:{connection.port}
+			</p>
+			<p class="text-xs text-muted-foreground truncate">
+				{connection.databaseName}
+			</p>
+			{#if connection.lastConnected}
+				<p class="text-xs text-muted-foreground">
+					Last connected {formatRelativeTime(connection.lastConnected)}
+				</p>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+</button>

--- a/src/lib/components/empty-states/connections-grid.svelte
+++ b/src/lib/components/empty-states/connections-grid.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import PlusIcon from "@lucide/svelte/icons/plus";
+	import { useDatabase } from "$lib/hooks/database.svelte.js";
+	import { connectionDialogStore } from "$lib/stores/connection-dialog.svelte.js";
+	import ConnectionCard from "./connection-card.svelte";
+
+	const db = useDatabase();
+
+	// Sort connections by last connected (most recent first)
+	const sortedConnections = $derived(
+		[...db.connections].sort((a, b) => {
+			const aTime = a.lastConnected?.getTime() ?? 0;
+			const bTime = b.lastConnected?.getTime() ?? 0;
+			return bTime - aTime;
+		})
+	);
+</script>
+
+<div class="flex-1 flex items-center justify-center p-8">
+	<div class="max-w-3xl w-full space-y-6">
+		<div class="text-center space-y-1">
+			<h1 class="text-xl font-semibold">Select a Connection</h1>
+			<p class="text-muted-foreground text-sm">Click a connection to get started</p>
+		</div>
+
+		<div class="flex flex-wrap justify-center items-stretch gap-4">
+			<div class="w-56">
+				<button
+					type="button"
+					class="w-full h-full flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-muted-foreground/25 hover:border-muted-foreground/50 hover:bg-muted/50 transition-colors cursor-pointer"
+					onclick={() => connectionDialogStore.open()}
+				>
+					<PlusIcon class="size-8 text-muted-foreground" />
+					<span class="text-sm text-muted-foreground">Add Connection</span>
+				</button>
+			</div>
+			{#each sortedConnections as connection (connection.id)}
+				<div class="w-56">
+					<ConnectionCard {connection} />
+				</div>
+			{/each}
+		</div>
+	</div>
+</div>

--- a/src/lib/components/empty-states/welcome-screen.svelte
+++ b/src/lib/components/empty-states/welcome-screen.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { Button } from "$lib/components/ui/button/index.js";
+	import * as Card from "$lib/components/ui/card/index.js";
+	import DatabaseIcon from "@lucide/svelte/icons/database";
+	import FileCodeIcon from "@lucide/svelte/icons/file-code";
+	import TableIcon from "@lucide/svelte/icons/table";
+	import NetworkIcon from "@lucide/svelte/icons/network";
+	import BotIcon from "@lucide/svelte/icons/bot";
+	import PlusIcon from "@lucide/svelte/icons/plus";
+	import { connectionDialogStore } from "$lib/stores/connection-dialog.svelte.js";
+
+	const features = [
+		{
+			icon: FileCodeIcon,
+			title: "Query Editor",
+			description: "Write and execute SQL queries with syntax highlighting",
+		},
+		{
+			icon: TableIcon,
+			title: "Schema Browser",
+			description: "Explore tables, columns, and relationships",
+		},
+		{
+			icon: NetworkIcon,
+			title: "ERD Viewer",
+			description: "Visualize your database structure",
+		},
+		{
+			icon: BotIcon,
+			title: "AI Assistant",
+			description: "Get help writing queries with AI",
+		},
+	];
+</script>
+
+<div class="flex-1 flex items-center justify-center p-8">
+	<div class="max-w-2xl w-full space-y-8">
+		<div class="text-center space-y-4">
+			<div class="flex justify-center">
+				<div class="p-4 rounded-full bg-muted">
+					<DatabaseIcon class="size-12 text-muted-foreground" />
+				</div>
+			</div>
+			<div>
+				<h1 class="text-2xl font-semibold">Welcome to Seaquel</h1>
+				<p class="text-muted-foreground mt-1">Connect to a database to get started</p>
+			</div>
+			<Button size="lg" onclick={() => connectionDialogStore.open()}>
+				<PlusIcon class="size-4 mr-2" />
+				Add Your First Connection
+			</Button>
+		</div>
+
+		<div class="grid grid-cols-2 gap-4">
+			{#each features as feature}
+				<Card.Root class="bg-muted/30">
+					<Card.Header class="pb-2">
+						<div class="flex items-center gap-2">
+							<feature.icon class="size-4 text-muted-foreground" />
+							<Card.Title class="text-sm font-medium">{feature.title}</Card.Title>
+						</div>
+					</Card.Header>
+					<Card.Content class="pt-0">
+						<p class="text-xs text-muted-foreground">{feature.description}</p>
+					</Card.Content>
+				</Card.Root>
+			{/each}
+		</div>
+	</div>
+</div>

--- a/src/lib/components/sidebar-left.svelte
+++ b/src/lib/components/sidebar-left.svelte
@@ -288,7 +288,7 @@
 		{/if}
 	</SidebarContent>
 
-	<SidebarFooter class="border-t border-sidebar-border p-4">
+	<SidebarFooter class="p-4">
 		<div class="text-xs text-muted-foreground">
 			{#if db.activeConnection}
 				{#if sidebarTab === "schema"}

--- a/src/lib/stores/connection-dialog.svelte.ts
+++ b/src/lib/stores/connection-dialog.svelte.ts
@@ -1,0 +1,30 @@
+import type { DatabaseType } from "$lib/types";
+
+export interface ConnectionDialogPrefill {
+	id?: string;
+	name?: string;
+	type?: DatabaseType;
+	host?: string;
+	port?: number;
+	databaseName?: string;
+	username?: string;
+	sslMode?: string;
+	connectionString?: string;
+}
+
+class ConnectionDialogStore {
+	isOpen = $state(false);
+	prefill = $state<ConnectionDialogPrefill | undefined>(undefined);
+
+	open(prefill?: ConnectionDialogPrefill) {
+		this.prefill = prefill;
+		this.isOpen = true;
+	}
+
+	close() {
+		this.isOpen = false;
+		this.prefill = undefined;
+	}
+}
+
+export const connectionDialogStore = new ConnectionDialogStore();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,8 @@
     import ExplainViewer from "$lib/components/explain-viewer.svelte";
     import ErdViewer from "$lib/components/erd-viewer.svelte";
     import AIAssistant from "$lib/components/ai-assistant.svelte";
+    import WelcomeScreen from "$lib/components/empty-states/welcome-screen.svelte";
+    import ConnectionsGrid from "$lib/components/empty-states/connections-grid.svelte";
     import { ScrollArea } from "$lib/components/ui/scroll-area";
     import { Button } from "$lib/components/ui/button";
     import { Input } from "$lib/components/ui/input";
@@ -265,7 +267,9 @@
 
 <Toaster position="bottom-right" richColors />
 
-<SidebarLeft />
+{#if db.activeConnectionId}
+    <SidebarLeft />
+{/if}
 <SidebarInset class="flex flex-col h-full overflow-hidden">
     {#if db.activeConnectionId}
         <!-- Unified Tab Bar -->
@@ -491,6 +495,10 @@
                 <ErdViewer />
             {/if}
         </div>
+    {:else if db.connections.length === 0}
+        <WelcomeScreen />
+    {:else}
+        <ConnectionsGrid />
     {/if}
 </SidebarInset>
 


### PR DESCRIPTION
## Summary
- Add welcome screen when no connections exist, featuring app branding and feature highlights
- Add connections grid when connections exist but none is active, with quick reconnect cards
- Hide left sidebar until a connection is active for cleaner empty state UX
- Add context menu to connection badges with Connect/Disconnect and Remove Connection options
- Add confirmation dialog before permanently removing a connection
- Create shared connection dialog store for cross-component access

## Test plan
- [ ] Launch app with no saved connections → should see welcome screen
- [ ] Add a connection, then disconnect → should see connections grid
- [ ] Right-click connection badge → should see context menu with appropriate options
- [ ] Remove a connection via context menu → should show confirmation dialog
- [ ] Confirm removal → connection should be deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)