### PR TITLE
Add drag & drop support for tab reordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "html-to-image": "^1.11.13",
         "monaco-editor": "^0.55.1",
         "monaco-sql-languages": "^0.15.1",
-        "sql-formatter": "^15.6.12"
+        "sql-formatter": "^15.6.12",
+        "svelte-dnd-action": "^0.9.69"
       },
       "devDependencies": {
         "@internationalized/date": "^3.10.0",
@@ -3566,6 +3567,15 @@
       "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0-next.0",
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/svelte-dnd-action": {
+      "version": "0.9.69",
+      "resolved": "https://registry.npmjs.org/svelte-dnd-action/-/svelte-dnd-action-0.9.69.tgz",
+      "integrity": "sha512-NAmSOH7htJoYraTQvr+q5whlIuVoq88vEuHr4NcFgscDRUxfWPPxgie2OoxepBCQCikrXZV4pqV86aun60wVyw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "svelte": ">=3.23.0 || ^5.0.0-next.0"
       }
     },
     "node_modules/svelte-sonner": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "html-to-image": "^1.11.13",
     "monaco-editor": "^0.55.1",
     "monaco-sql-languages": "^0.15.1",
-    "sql-formatter": "^15.6.12"
+    "sql-formatter": "^15.6.12",
+    "svelte-dnd-action": "^0.9.69"
   },
   "devDependencies": {
     "@internationalized/date": "^3.10.0",

--- a/src/lib/hooks/database/query-tabs.svelte.ts
+++ b/src/lib/hooks/database/query-tabs.svelte.ts
@@ -15,7 +15,8 @@ export class QueryTabManager {
       activeIdGetter: () => Map<string, string | null>,
       activeIdSetter: (m: Map<string, string | null>) => void,
       tabId: string
-    ) => void
+    ) => void,
+    private addToTabOrder: (tabId: string) => void
   ) {}
 
   addQueryTab(name?: string, query?: string, savedQueryId?: string): string | null {
@@ -39,6 +40,7 @@ export class QueryTabManager {
     newActiveQueryIds.set(this.state.activeConnectionId, newTab.id);
     this.state.activeQueryTabIdByConnection = newActiveQueryIds;
 
+    this.addToTabOrder(newTab.id);
     this.schedulePersistence(this.state.activeConnectionId);
     return newTab.id;
   }

--- a/src/lib/hooks/database/state.svelte.ts
+++ b/src/lib/hooks/database/state.svelte.ts
@@ -41,6 +41,9 @@ export class DatabaseState {
   erdTabsByConnection = $state<Map<string, ErdTab[]>>(new Map());
   activeErdTabIdByConnection = $state<Map<string, string | null>>(new Map());
 
+  // Tab ordering state (stores ordered array of all tab IDs per connection)
+  tabOrderByConnection = $state<Map<string, string[]>>(new Map());
+
   // AI state
   aiMessages = $state<AIMessage[]>([]);
   isAIOpen = $state(false);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -218,6 +218,7 @@ export interface PersistedConnectionState {
 	schemaTabs: PersistedSchemaTab[];
 	explainTabs: PersistedExplainTab[];
 	erdTabs: PersistedErdTab[];
+	tabOrder: string[];
 	activeQueryTabId: string | null;
 	activeSchemaTabId: string | null;
 	activeExplainTabId: string | null;


### PR DESCRIPTION
## Summary
- Add drag & drop support to reorder tabs (Query, Schema, Explain, ERD) in the unified tab bar
- Use svelte-dnd-action library for smooth drag & drop with flip animations
- Persist tab order across app restarts with backward compatibility for existing users

## Changes
- Install `svelte-dnd-action` library
- Add `tabOrderByConnection` state and `tabOrder` to persisted state
- Add `reorderTabs()` method and `orderedTabs` getter
- Integrate `dndzone` action in tab bar UI with `animate:flip`
- Disable drag while editing tab names

## Test plan
- [ ] Drag tabs to reorder them
- [ ] Verify order persists after app restart
- [ ] Verify new tabs appear at the end
- [ ] Verify tab removal updates order correctly
- [ ] Verify editing tab names still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)