### PR TITLE
Fix SQLite multiple connections and UI scroll issues

### DIFF
--- a/src/lib/components/app-header.svelte
+++ b/src/lib/components/app-header.svelte
@@ -6,7 +6,6 @@
     import * as ContextMenu from "$lib/components/ui/context-menu/index.js";
     import * as Dialog from "$lib/components/ui/dialog/index.js";
     import { useDatabase } from "$lib/hooks/database.svelte.js";
-    import { ScrollArea } from "$lib/components/ui/scroll-area";
     import ConnectionDialog from "$lib/components/connection-dialog.svelte";
     import XIcon from "@lucide/svelte/icons/x";
     import PlusIcon from "@lucide/svelte/icons/plus";
@@ -71,9 +70,9 @@
         data-tauri-drag-region
         class="pl-18 h-(--header-height) flex w-full items-center gap-2 pr-2 justify-between"
     >
-        <div class="flex items-center gap-1">
+        <div class="flex items-center gap-1 flex-1 min-w-0">
             <Button
-                class="size-8"
+                class="size-8 shrink-0"
                 variant="ghost"
                 size="icon"
                 onclick={sidebar.toggle}
@@ -81,8 +80,8 @@
                 <SidebarIcon />
             </Button>
             {#if db.connections.length > 0}
-                <ScrollArea orientation="horizontal" class="flex-1">
-                    <div class="flex items-center gap-1">
+                <div class="flex-1 overflow-x-auto overflow-y-hidden min-w-0 scrollbar-hide">
+                    <div class="flex items-center gap-1 w-max">
                         {#each db.connections as connection (connection.id)}
                             <ContextMenu.Root>
                                 <ContextMenu.Trigger>
@@ -158,7 +157,7 @@
                             <PlusIcon class="size-4" />
                         </Button>
                     </div>
-                </ScrollArea>
+                </div>
             {:else}
                 <Badge
                     variant="outline"

--- a/src/lib/components/empty-states/connections-grid.svelte
+++ b/src/lib/components/empty-states/connections-grid.svelte
@@ -16,8 +16,8 @@
 	);
 </script>
 
-<div class="flex-1 flex items-center justify-center p-8">
-	<div class="max-w-3xl w-full space-y-6">
+<div class="flex-1 overflow-y-auto p-8">
+	<div class="max-w-3xl mx-auto space-y-6">
 		<div class="text-center space-y-1">
 			<h1 class="text-xl font-semibold">Select a Connection</h1>
 			<p class="text-muted-foreground text-sm">Click a connection to get started</p>

--- a/src/lib/hooks/database.svelte.ts
+++ b/src/lib/hooks/database.svelte.ts
@@ -732,7 +732,10 @@ class UseDatabase extends DatabaseState {
         toast.success(`SSH tunnel established on port ${tunnelResult.localPort}`);
 
         // Store tunnel ID for later cleanup
-        const connectionId = `conn-${connection.host}-${connection.port}`;
+        const connectionId =
+          connection.type === 'sqlite'
+            ? `conn-sqlite-${connection.databaseName}`
+            : `conn-${connection.host}-${connection.port}`;
         this.tunnelIds.set(connectionId, tunnelResult.tunnelId);
       } catch (error) {
         toast.error(`SSH tunnel failed: ${error}`);
@@ -742,7 +745,10 @@ class UseDatabase extends DatabaseState {
 
     const newConnection: DatabaseConnection = {
       ...connection,
-      id: `conn-${connection.host}-${connection.port}`,
+      id:
+        connection.type === 'sqlite'
+          ? `conn-sqlite-${connection.databaseName}`
+          : `conn-${connection.host}-${connection.port}`,
       lastConnected: new Date(),
       tunnelLocalPort,
       database: effectiveConnectionString


### PR DESCRIPTION
## Summary
- Fix duplicate SQLite connections only showing first one by making connection ID generation database-type aware (uses file path for SQLite instead of host:port)
- Add horizontal scroll to connection tabs in header (matching editor/schema tabs pattern)
- Add vertical scroll to connections grid when many disconnected connections exist

## Test plan
- [ ] Add two SQLite connections with different database files - both should appear
- [ ] Add many connections and verify header tabs scroll horizontally
- [ ] Disconnect 10+ connections and verify the grid scrolls vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)