### PR TITLE
Add command palette (Cmd+K / Ctrl+K)

### DIFF
--- a/src/lib/components/command-palette.svelte
+++ b/src/lib/components/command-palette.svelte
@@ -1,0 +1,426 @@
+<script lang="ts">
+	import * as Command from "$lib/components/ui/command";
+	import { useDatabase } from "$lib/hooks/database.svelte";
+	import { useShortcuts } from "$lib/shortcuts/shortcuts.svelte";
+	import { connectionDialogStore } from "$lib/stores/connection-dialog.svelte";
+	import {
+		Plus,
+		Play,
+		Save,
+		Table2,
+		Database,
+		History,
+		FileText,
+		Sparkles,
+		PanelLeft,
+		Download,
+		Copy,
+		GitBranch,
+		Code,
+	} from "@lucide/svelte";
+
+	const db = useDatabase();
+	const shortcuts = useShortcuts();
+
+	let open = $state(false);
+
+	// Derived state for dynamic commands
+	const tables = $derived(
+		db.activeConnectionId ? db.schemas.get(db.activeConnectionId) || [] : []
+	);
+	const connections = $derived(db.connections);
+	const savedQueries = $derived(db.activeConnectionSavedQueries);
+	const recentHistory = $derived(db.activeConnectionQueryHistory?.slice(0, 10) || []);
+	const openTabs = $derived(db.orderedTabs);
+	const hasResults = $derived((db.activeQueryTab?.results?.rows?.length ?? 0) > 0);
+	const isConnected = $derived(!!db.activeConnectionId && !!db.activeConnection?.database);
+	const hasActiveQueryTab = $derived(isConnected && !!db.activeQueryTab);
+	const hasQueryContent = $derived(hasActiveQueryTab && !!db.activeQueryTab?.query?.trim());
+	const hasConnections = $derived(connections.length > 0);
+
+	// Register shortcut handler
+	$effect(() => {
+		shortcuts.registerHandler("commandPalette", () => {
+			open = !open;
+		});
+		return () => shortcuts.unregisterHandler("commandPalette");
+	});
+
+	function runAndClose(action: () => void) {
+		action();
+		open = false;
+	}
+
+	// Actions
+	function newQueryTab() {
+		runAndClose(() => db.addQueryTab());
+	}
+
+	function executeQuery() {
+		const tab = db.activeQueryTab;
+		if (tab) {
+			runAndClose(() => db.executeQuery(tab.id));
+		}
+	}
+
+	function saveQuery() {
+		// This triggers the save dialog - we just close the palette
+		// The save handler needs to be in the parent component
+		runAndClose(() => {
+			// Dispatch a custom event to open save dialog
+			window.dispatchEvent(new CustomEvent("open-save-query-dialog"));
+		});
+	}
+
+	function toggleAI() {
+		runAndClose(() => db.toggleAI());
+	}
+
+	function goToTab(tabId: string, type: "query" | "schema" | "explain" | "erd") {
+		runAndClose(() => {
+			switch (type) {
+				case "query":
+					db.setActiveQueryTab(tabId);
+					db.setActiveView("query");
+					break;
+				case "schema":
+					db.setActiveSchemaTab(tabId);
+					db.setActiveView("schema");
+					break;
+				case "explain":
+					db.setActiveExplainTab(tabId);
+					db.setActiveView("explain");
+					break;
+				case "erd":
+					db.setActiveErdTab(tabId);
+					db.setActiveView("erd");
+					break;
+			}
+		});
+	}
+
+	function toggleSidebar() {
+		runAndClose(() => {
+			// Trigger the toggle sidebar shortcut
+			const handler = shortcuts as any;
+			handler.handlers.get("toggleSidebar")?.();
+		});
+	}
+
+	function openTable(table: { name: string; schema: string }) {
+		const schemaTable = tables.find(
+			(t) => t.name === table.name && t.schema === table.schema
+		);
+		if (schemaTable) {
+			runAndClose(() => {
+				db.addSchemaTab(schemaTable);
+				db.setActiveView("schema");
+			});
+		}
+	}
+
+	function queryTable(table: { name: string; schema: string }) {
+		runAndClose(() => {
+			const query = `SELECT * FROM "${table.schema}"."${table.name}" LIMIT 100`;
+			db.addQueryTab(`Query: ${table.name}`, query);
+			db.setActiveView("query");
+		});
+	}
+
+	function viewErd() {
+		runAndClose(() => db.addErdTab());
+	}
+
+	function switchConnection(id: string) {
+		const connection = connections.find((c) => c.id === id);
+		if (!connection) return;
+
+		if (connection.database) {
+			// Already connected, just switch to it
+			runAndClose(() => db.setActiveConnection(id));
+		} else {
+			// Disconnected, open the reconnect dialog
+			open = false;
+			connectionDialogStore.open({
+				id: connection.id,
+				name: connection.name,
+				type: connection.type,
+				host: connection.host,
+				port: connection.port,
+				databaseName: connection.databaseName,
+				username: connection.username,
+				sslMode: connection.sslMode,
+				connectionString: connection.connectionString,
+				sshTunnel: connection.sshTunnel,
+			});
+		}
+	}
+
+	function loadSavedQuery(id: string) {
+		runAndClose(() => db.loadSavedQuery(id));
+	}
+
+	function loadHistoryItem(id: string) {
+		runAndClose(() => db.loadQueryFromHistory(id));
+	}
+
+	function exportResults(format: "csv" | "json") {
+		const results = db.activeQueryTab?.results;
+		if (!results) return;
+
+		let content: string;
+		let filename: string;
+		const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+		if (format === "csv") {
+			const headers = results.columns.join(",");
+			const rows = results.rows
+				.map((row) =>
+					results.columns
+						.map((col) => {
+							const val = row[col];
+							if (val === null || val === undefined) return "";
+							const str = String(val);
+							return str.includes(",") || str.includes('"') || str.includes("\n")
+								? `"${str.replace(/"/g, '""')}"`
+								: str;
+						})
+						.join(",")
+				)
+				.join("\n");
+			content = `${headers}\n${rows}`;
+			filename = `query-results-${timestamp}.csv`;
+		} else {
+			content = JSON.stringify(results.rows, null, 2);
+			filename = `query-results-${timestamp}.json`;
+		}
+
+		const blob = new Blob([content], { type: format === "csv" ? "text/csv" : "application/json" });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = filename;
+		a.click();
+		URL.revokeObjectURL(url);
+
+		open = false;
+	}
+
+	function copyResults() {
+		const results = db.activeQueryTab?.results;
+		if (!results) return;
+
+		const content = JSON.stringify(results.rows, null, 2);
+		navigator.clipboard.writeText(content);
+		open = false;
+	}
+
+	function explainQuery() {
+		const tab = db.activeQueryTab;
+		if (tab) {
+			runAndClose(() => db.executeExplain(tab.id, false));
+		}
+	}
+
+	function explainAnalyzeQuery() {
+		const tab = db.activeQueryTab;
+		if (tab) {
+			runAndClose(() => db.executeExplain(tab.id, true));
+		}
+	}
+
+	function getTabName(tab: { type: string; tab: any }): string {
+		switch (tab.type) {
+			case "query":
+				return tab.tab.name || "Query";
+			case "schema":
+				return tab.tab.table?.name || "Schema";
+			case "explain":
+				return tab.tab.name || "Explain";
+			case "erd":
+				return tab.tab.name || "ERD";
+			default:
+				return "Tab";
+		}
+	}
+
+	function getTabIcon(type: string) {
+		switch (type) {
+			case "query":
+				return Code;
+			case "schema":
+				return Table2;
+			case "explain":
+				return GitBranch;
+			case "erd":
+				return GitBranch;
+			default:
+				return FileText;
+		}
+	}
+
+	function truncateQuery(query: string, maxLength: number = 50): string {
+		const cleaned = query.replace(/\s+/g, " ").trim();
+		return cleaned.length > maxLength ? cleaned.substring(0, maxLength) + "..." : cleaned;
+	}
+</script>
+
+<Command.Dialog bind:open title="Command Palette" description="Search for a command or action">
+	<Command.Input placeholder="Search commands..." />
+	<Command.List>
+		<Command.Empty>No results found.</Command.Empty>
+
+		<!-- Quick Actions (only show group if there are actions available) -->
+		{#if isConnected || hasConnections}
+			<Command.Group heading="Quick Actions">
+				{#if isConnected}
+					<Command.Item value="new-query-tab" onSelect={newQueryTab}>
+						<Plus class="size-4" />
+						<span>New Query Tab</span>
+						<Command.Shortcut>⌘T</Command.Shortcut>
+					</Command.Item>
+				{/if}
+				{#if hasQueryContent}
+					<Command.Item value="execute-query" onSelect={executeQuery}>
+						<Play class="size-4" />
+						<span>Execute Query</span>
+						<Command.Shortcut>⌘↵</Command.Shortcut>
+					</Command.Item>
+					<Command.Item value="save-query" onSelect={saveQuery}>
+						<Save class="size-4" />
+						<span>Save Query</span>
+						<Command.Shortcut>⌘S</Command.Shortcut>
+					</Command.Item>
+					<Command.Item value="explain-query" onSelect={explainQuery}>
+						<GitBranch class="size-4" />
+						<span>Explain Query</span>
+					</Command.Item>
+					<Command.Item value="explain-analyze-query" onSelect={explainAnalyzeQuery}>
+						<GitBranch class="size-4" />
+						<span>Explain Analyze Query</span>
+					</Command.Item>
+				{/if}
+				<Command.Item value="toggle-ai" onSelect={toggleAI}>
+					<Sparkles class="size-4" />
+					<span>Toggle AI Assistant</span>
+				</Command.Item>
+			</Command.Group>
+		{/if}
+
+		<!-- Navigation -->
+		{#if openTabs.length > 0}
+			<Command.Group heading="Open Tabs">
+				{#each openTabs as tab}
+					{@const TabIcon = getTabIcon(tab.type)}
+					<Command.Item value="tab-{tab.id}" onSelect={() => goToTab(tab.id, tab.type)}>
+						<TabIcon class="size-4" />
+						<span>{getTabName(tab)}</span>
+						<span class="text-muted-foreground ml-auto text-xs">{tab.type}</span>
+					</Command.Item>
+				{/each}
+			</Command.Group>
+		{/if}
+
+		<Command.Group heading="Navigation">
+			<Command.Item value="toggle-sidebar" onSelect={toggleSidebar}>
+				<PanelLeft class="size-4" />
+				<span>Toggle Sidebar</span>
+				<Command.Shortcut>⌘B</Command.Shortcut>
+			</Command.Item>
+			{#if isConnected}
+				<Command.Item value="view-erd" onSelect={viewErd}>
+					<GitBranch class="size-4" />
+					<span>View ERD Diagram</span>
+				</Command.Item>
+			{/if}
+		</Command.Group>
+
+		<!-- Tables -->
+		{#if isConnected && tables.length > 0}
+			<Command.Group heading="Tables">
+				{#each tables.slice(0, 20) as table}
+					<Command.Item value="open-table-{table.schema}-{table.name}" onSelect={() => openTable(table)}>
+						<Table2 class="size-4" />
+						<span>Open: {table.schema}.{table.name}</span>
+					</Command.Item>
+				{/each}
+				{#each tables.slice(0, 20) as table}
+					<Command.Item value="query-table-{table.schema}-{table.name}" onSelect={() => queryTable(table)}>
+						<Play class="size-4" />
+						<span>Query: {table.schema}.{table.name}</span>
+					</Command.Item>
+				{/each}
+			</Command.Group>
+		{/if}
+
+		<!-- Connections -->
+		{#if hasConnections}
+			<Command.Group heading="Connections">
+				{#each connections as connection}
+					<Command.Item value="connection-{connection.id}" onSelect={() => switchConnection(connection.id)}>
+						<Database class="size-4" />
+						<span>
+							{#if connection.id === db.activeConnectionId}
+								{connection.name}
+							{:else if connection.database}
+								Switch to: {connection.name}
+							{:else}
+								Connect: {connection.name}
+							{/if}
+						</span>
+						{#if connection.id === db.activeConnectionId}
+							<span class="text-muted-foreground ml-auto text-xs">active</span>
+						{:else if !connection.database}
+							<span class="text-muted-foreground ml-auto text-xs">disconnected</span>
+						{/if}
+					</Command.Item>
+				{/each}
+			</Command.Group>
+		{/if}
+
+		<!-- Saved Queries -->
+		{#if isConnected && savedQueries && savedQueries.length > 0}
+			<Command.Group heading="Saved Queries">
+				{#each savedQueries as query}
+					<Command.Item value="saved-query-{query.id}" onSelect={() => loadSavedQuery(query.id)}>
+						<FileText class="size-4" />
+						<span>{query.name}</span>
+					</Command.Item>
+				{/each}
+			</Command.Group>
+		{/if}
+
+		<!-- Query History -->
+		{#if isConnected && recentHistory.length > 0}
+			<Command.Group heading="Recent Queries">
+				{#each recentHistory as item}
+					<Command.Item value="history-{item.id}" onSelect={() => loadHistoryItem(item.id)}>
+						<History class="size-4" />
+						<span class="truncate">{truncateQuery(item.query)}</span>
+						<span class="text-muted-foreground ml-auto shrink-0 text-xs"
+							>{item.executionTime}ms</span
+						>
+					</Command.Item>
+				{/each}
+			</Command.Group>
+		{/if}
+
+		<!-- Results Actions -->
+		{#if hasResults}
+			<Command.Group heading="Results">
+				<Command.Item value="export-csv" onSelect={() => exportResults("csv")}>
+					<Download class="size-4" />
+					<span>Export as CSV</span>
+				</Command.Item>
+				<Command.Item value="export-json" onSelect={() => exportResults("json")}>
+					<Download class="size-4" />
+					<span>Export as JSON</span>
+				</Command.Item>
+				<Command.Item value="copy-results" onSelect={copyResults}>
+					<Copy class="size-4" />
+					<span>Copy Results as JSON</span>
+				</Command.Item>
+			</Command.Group>
+		{/if}
+	</Command.List>
+</Command.Dialog>

--- a/src/lib/components/ui/command/command-dialog.svelte
+++ b/src/lib/components/ui/command/command-dialog.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import type { Command as CommandPrimitive, Dialog as DialogPrimitive } from "bits-ui";
+	import type { Snippet } from "svelte";
+	import Command from "./command.svelte";
+	import * as Dialog from "$lib/components/ui/dialog/index.js";
+	import type { WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		open = $bindable(false),
+		ref = $bindable(null),
+		value = $bindable(""),
+		title = "Command Palette",
+		description = "Search for a command to run",
+		portalProps,
+		children,
+		...restProps
+	}: WithoutChildrenOrChild<DialogPrimitive.RootProps> &
+		WithoutChildrenOrChild<CommandPrimitive.RootProps> & {
+			portalProps?: DialogPrimitive.PortalProps;
+			children: Snippet;
+			title?: string;
+			description?: string;
+		} = $props();
+</script>
+
+<Dialog.Root bind:open {...restProps}>
+	<Dialog.Header class="sr-only">
+		<Dialog.Title>{title}</Dialog.Title>
+		<Dialog.Description>{description}</Dialog.Description>
+	</Dialog.Header>
+	<Dialog.Content class="overflow-hidden p-0" {portalProps}>
+		<Command
+			class="**:data-[slot=command-input-wrapper]:h-12 [&_[data-command-group]]:px-2 [&_[data-command-group]:not([hidden])_~[data-command-group]]:pt-0 [&_[data-command-input-wrapper]_svg]:h-5 [&_[data-command-input-wrapper]_svg]:w-5 [&_[data-command-input]]:h-12 [&_[data-command-item]]:px-2 [&_[data-command-item]]:py-3 [&_[data-command-item]_svg]:h-5 [&_[data-command-item]_svg]:w-5"
+			{...restProps}
+			bind:value
+			bind:ref
+			{children}
+		/>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/ui/command/command-empty.svelte
+++ b/src/lib/components/ui/command/command-empty.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CommandPrimitive.EmptyProps = $props();
+</script>
+
+<CommandPrimitive.Empty
+	bind:ref
+	data-slot="command-empty"
+	class={cn("py-6 text-center text-sm", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/command/command-group.svelte
+++ b/src/lib/components/ui/command/command-group.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { Command as CommandPrimitive, useId } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		heading,
+		value,
+		...restProps
+	}: CommandPrimitive.GroupProps & {
+		heading?: string;
+	} = $props();
+</script>
+
+<CommandPrimitive.Group
+	bind:ref
+	data-slot="command-group"
+	class={cn("text-foreground overflow-hidden p-1", className)}
+	value={value ?? heading ?? `----${useId()}`}
+	{...restProps}
+>
+	{#if heading}
+		<CommandPrimitive.GroupHeading
+			class="text-muted-foreground px-2 py-1.5 text-xs font-medium"
+		>
+			{heading}
+		</CommandPrimitive.GroupHeading>
+	{/if}
+	<CommandPrimitive.GroupItems {children} />
+</CommandPrimitive.Group>

--- a/src/lib/components/ui/command/command-input.svelte
+++ b/src/lib/components/ui/command/command-input.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "bits-ui";
+	import SearchIcon from "@lucide/svelte/icons/search";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		value = $bindable(""),
+		...restProps
+	}: CommandPrimitive.InputProps = $props();
+</script>
+
+<div class="flex h-9 items-center gap-2 border-b ps-3 pe-8" data-slot="command-input-wrapper">
+	<SearchIcon class="size-4 shrink-0 opacity-50" />
+	<CommandPrimitive.Input
+		data-slot="command-input"
+		class={cn(
+			"placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+			className
+		)}
+		bind:ref
+		{...restProps}
+		bind:value
+	/>
+</div>

--- a/src/lib/components/ui/command/command-item.svelte
+++ b/src/lib/components/ui/command/command-item.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CommandPrimitive.ItemProps = $props();
+</script>
+
+<CommandPrimitive.Item
+	bind:ref
+	data-slot="command-item"
+	class={cn(
+		"aria-selected:bg-accent aria-selected:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/command/command-link-item.svelte
+++ b/src/lib/components/ui/command/command-link-item.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CommandPrimitive.LinkItemProps = $props();
+</script>
+
+<CommandPrimitive.LinkItem
+	bind:ref
+	data-slot="command-item"
+	class={cn(
+		"aria-selected:bg-accent aria-selected:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/command/command-list.svelte
+++ b/src/lib/components/ui/command/command-list.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CommandPrimitive.ListProps = $props();
+</script>
+
+<CommandPrimitive.List
+	bind:ref
+	data-slot="command-list"
+	class={cn("max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/command/command-loading.svelte
+++ b/src/lib/components/ui/command/command-loading.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: CommandPrimitive.LoadingProps = $props();
+</script>
+
+<CommandPrimitive.Loading bind:ref {...restProps} />

--- a/src/lib/components/ui/command/command-separator.svelte
+++ b/src/lib/components/ui/command/command-separator.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: CommandPrimitive.SeparatorProps = $props();
+</script>
+
+<CommandPrimitive.Separator
+	bind:ref
+	data-slot="command-separator"
+	class={cn("bg-border -mx-1 h-px", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/command/command-shortcut.svelte
+++ b/src/lib/components/ui/command/command-shortcut.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
+</script>
+
+<span
+	bind:this={ref}
+	data-slot="command-shortcut"
+	class={cn("text-muted-foreground ms-auto text-xs tracking-widest", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</span>

--- a/src/lib/components/ui/command/command.svelte
+++ b/src/lib/components/ui/command/command.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { Command as CommandPrimitive } from "bits-ui";
+
+	export type CommandRootApi = CommandPrimitive.Root;
+
+	let {
+		api = $bindable(null),
+		ref = $bindable(null),
+		value = $bindable(""),
+		class: className,
+		...restProps
+	}: CommandPrimitive.RootProps & {
+		api?: CommandRootApi | null;
+	} = $props();
+</script>
+
+<CommandPrimitive.Root
+	bind:this={api}
+	bind:value
+	bind:ref
+	data-slot="command"
+	class={cn(
+		"bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/command/index.ts
+++ b/src/lib/components/ui/command/index.ts
@@ -1,0 +1,37 @@
+import Root from "./command.svelte";
+import Loading from "./command-loading.svelte";
+import Dialog from "./command-dialog.svelte";
+import Empty from "./command-empty.svelte";
+import Group from "./command-group.svelte";
+import Item from "./command-item.svelte";
+import Input from "./command-input.svelte";
+import List from "./command-list.svelte";
+import Separator from "./command-separator.svelte";
+import Shortcut from "./command-shortcut.svelte";
+import LinkItem from "./command-link-item.svelte";
+
+export {
+	Root,
+	Dialog,
+	Empty,
+	Group,
+	Item,
+	LinkItem,
+	Input,
+	List,
+	Separator,
+	Shortcut,
+	Loading,
+	//
+	Root as Command,
+	Dialog as CommandDialog,
+	Empty as CommandEmpty,
+	Group as CommandGroup,
+	Item as CommandItem,
+	LinkItem as CommandLinkItem,
+	Input as CommandInput,
+	List as CommandList,
+	Separator as CommandSeparator,
+	Shortcut as CommandShortcut,
+	Loading as CommandLoading,
+};

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -27,7 +27,7 @@
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed start-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+			"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
 			className
 		)}
 		{...restProps}
@@ -35,7 +35,7 @@
 		{@render children?.()}
 		{#if showCloseButton}
 			<DialogPrimitive.Close
-				class="ring-offset-background focus:ring-ring rounded-xs focus:outline-hidden absolute end-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+				class="ring-offset-background focus:ring-ring absolute end-4 top-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
 			>
 				<XIcon />
 				<span class="sr-only">Close</span>

--- a/src/lib/components/ui/dialog/dialog-title.svelte
+++ b/src/lib/components/ui/dialog/dialog-title.svelte
@@ -12,6 +12,6 @@
 <DialogPrimitive.Title
 	bind:ref
 	data-slot="dialog-title"
-	class={cn("text-lg font-semibold leading-none", className)}
+	class={cn("text-lg leading-none font-semibold", className)}
 	{...restProps}
 />

--- a/src/lib/shortcuts/registry.ts
+++ b/src/lib/shortcuts/registry.ts
@@ -19,6 +19,12 @@ export interface ShortcutDefinition {
 export const shortcuts: ShortcutDefinition[] = [
 	// General
 	{
+		id: "commandPalette",
+		keys: { mod: true, key: "k" },
+		description: "Open command palette",
+		category: "general",
+	},
+	{
 		id: "showShortcuts",
 		keys: { key: "?" },
 		description: "Show keyboard shortcuts",

--- a/src/lib/shortcuts/shortcuts.svelte.ts
+++ b/src/lib/shortcuts/shortcuts.svelte.ts
@@ -83,7 +83,7 @@ class ShortcutManager {
 
 	private isGlobalShortcut(shortcut: ShortcutDefinition): boolean {
 		// Shortcuts that should work even in input fields
-		const globalIds = ["toggleSidebar", "showShortcuts"];
+		const globalIds = ["toggleSidebar", "showShortcuts", "commandPalette"];
 		return globalIds.includes(shortcut.id);
 	}
 

--- a/src/lib/stores/connection-dialog.svelte.ts
+++ b/src/lib/stores/connection-dialog.svelte.ts
@@ -1,4 +1,4 @@
-import type { DatabaseType } from "$lib/types";
+import type { DatabaseType, SSHAuthMethod } from "$lib/types";
 
 export interface ConnectionDialogPrefill {
 	id?: string;
@@ -10,6 +10,13 @@ export interface ConnectionDialogPrefill {
 	username?: string;
 	sslMode?: string;
 	connectionString?: string;
+	sshTunnel?: {
+		enabled: boolean;
+		host: string;
+		port: number;
+		username: string;
+		authMethod: SSHAuthMethod;
+	};
 }
 
 class ConnectionDialogStore {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
     import { setDatabase, useDatabase } from "$lib/hooks/database.svelte.js";
     import { setShortcuts } from "$lib/shortcuts/index.js";
     import KeyboardShortcutsDialog from "$lib/components/keyboard-shortcuts-dialog.svelte";
+    import CommandPalette from "$lib/components/command-palette.svelte";
 
     setDatabase();
     const db = useDatabase();
@@ -24,6 +25,7 @@
 <ModeWatcher />
 <Toaster position="bottom-right" theme={"dark"} richColors />
 <KeyboardShortcutsDialog />
+<CommandPalette />
 
 <Sidebar.Provider class="[--header-height:calc(--spacing(8))] flex-col h-svh overflow-hidden">
     <AppHeader />


### PR DESCRIPTION
## Summary
- Add comprehensive command palette accessible via Cmd+K (Mac) or Ctrl+K (Windows/Linux)
- Context-aware commands that only show when executable
- Quick access to all major app actions

## Features
- **Quick Actions**: New tab, execute query, save query, explain query, AI toggle
- **Navigation**: Switch between open tabs, toggle sidebar, view ERD
- **Tables**: Open table schema or query any table dynamically
- **Connections**: Switch connections with status indicators, open reconnect dialog for disconnected
- **Saved Queries**: Load any saved query
- **Query History**: Load from recent 10 queries
- **Results**: Export CSV/JSON, copy results (when results exist)

## Test plan
- [ ] Press Cmd+K to open command palette
- [ ] Verify search filtering works
- [ ] Test executing commands from palette
- [ ] Verify disconnected connections open reconnect dialog
- [ ] Check context-awareness (commands hide when not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)