### PR TITLE
Show toast notification for app updates instead of auto-restart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tauri-apps/plugin-dialog": "^2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.4",
         "@tauri-apps/plugin-os": "^2.3.2",
+        "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-sql": "^2.3.1",
         "@tauri-apps/plugin-store": "^2.4.1",
         "@tauri-apps/plugin-updater": "^2.9.0",
@@ -1637,6 +1638,15 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-os/-/plugin-os-2.3.2.tgz",
       "integrity": "sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tauri-apps/plugin-dialog": "^2.4.2",
     "@tauri-apps/plugin-fs": "^2.4.4",
     "@tauri-apps/plugin-os": "^2.3.2",
+    "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-sql": "^2.3.1",
     "@tauri-apps/plugin-store": "^2.4.1",
     "@tauri-apps/plugin-updater": "^2.9.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4825,6 +4825,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-os",
+ "tauri-plugin-process",
  "tauri-plugin-sql",
  "tauri-plugin-store",
  "tauri-plugin-updater",
@@ -5867,6 +5868,16 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,4 +36,5 @@ image = "0.25.9"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -22,6 +22,7 @@
     "core:path:default",
     "os:default",
     "clipboard-manager:allow-write-image",
-    "clipboard-manager:allow-write-text"
+    "clipboard-manager:allow-write-text",
+    "process:allow-restart"
   ]
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,6 +8,9 @@
     import { setShortcuts } from "$lib/shortcuts/index.js";
     import KeyboardShortcutsDialog from "$lib/components/keyboard-shortcuts-dialog.svelte";
     import CommandPalette from "$lib/components/command-palette.svelte";
+    import { listen } from "@tauri-apps/api/event";
+    import { invoke } from "@tauri-apps/api/core";
+    import { toast } from "svelte-sonner";
 
     setDatabase();
     const db = useDatabase();
@@ -18,6 +21,21 @@
     function handleBeforeUnload() {
         db.flushPersistence();
     }
+
+    $effect(() => {
+        const unlisten = listen<string>("update-downloaded", (event) => {
+            toast.success(`Update v${event.payload} downloaded`, {
+                action: {
+                    label: "Install & Restart",
+                    onClick: () => invoke("install_update"),
+                },
+                duration: Infinity,
+            });
+        });
+        return () => {
+            unlisten.then((fn) => fn());
+        };
+    });
 </script>
 
 <svelte:window onkeydown={shortcuts.handleKeydown} onbeforeunload={handleBeforeUnload} />


### PR DESCRIPTION
## Summary
- Backend checks for updates and downloads them on startup (no auto-install)
- After download completes, emits `update-downloaded` event to frontend
- Frontend shows toast notification with "Install & Restart" button
- User controls when to install the update

## Test plan
- [ ] Build the app and verify it compiles
- [ ] Test that toast appears when an update is available
- [ ] Verify clicking "Install & Restart" installs the update and restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)