### PR TITLE
Fix query execution not working after database reconnection

### DIFF
--- a/src/lib/hooks/database/map-utils.ts
+++ b/src/lib/hooks/database/map-utils.ts
@@ -31,3 +31,28 @@ export function deleteMapKey<K, V>(
   newMap.delete(key);
   setter(newMap);
 }
+
+/**
+ * Update a specific item in an array stored in a Map while maintaining reactivity.
+ * Creates new Map and array instances, and replaces the item with updated properties.
+ */
+export function updateMapArrayItem<K, T extends { id: string }>(
+  getter: () => Map<K, T[]>,
+  setter: (m: Map<K, T[]>) => void,
+  mapKey: K,
+  itemId: string,
+  updates: Partial<T>
+): void {
+  const currentMap = getter();
+  const currentArray = currentMap.get(mapKey) || [];
+
+  // Create new array with updated item
+  const newArray = currentArray.map(item =>
+    item.id === itemId ? { ...item, ...updates } : item
+  );
+
+  // Create new Map with new array
+  const newMap = new Map(currentMap);
+  newMap.set(mapKey, newArray);
+  setter(newMap);
+}


### PR DESCRIPTION
## Summary
- Fix Svelte 5 reactivity issue where `connection.database` wasn't updating after reconnection
- Add `updateMapArrayItem` helper for proper Map reactivity when updating array items
- Refactor `executeQuery` to use reactive state updates for results/isExecuting
- Add guard check with toast error when database connection is unavailable

## Problem
When reconnecting to a database that already had query tabs open, executing queries via Cmd+Enter or clicking Execute did nothing. This was caused by two Svelte 5 reactivity issues:

1. The connection object was being mutated in place, so the derived `activeConnection` value didn't see the updated `database` property
2. Query tab results were being mutated directly instead of through proper reactive updates

## Solution
- Create new connection objects when reconnecting instead of mutating existing ones
- Add `updateMapArrayItem` utility that creates new Map and array instances
- Use `updateQueryTabState` helper to properly update tab state with reactivity

## Test plan
- [ ] Connect to a database
- [ ] Create a query tab and run a query
- [ ] Disconnect (or close/reopen the app)
- [ ] Reconnect to the database
- [ ] Execute the query again - should work now

🤖 Generated with [Claude Code](https://claude.com/claude-code)