### PR TITLE
Always use virtual table with resizable columns

### DIFF
--- a/src/lib/components/query-editor.svelte
+++ b/src/lib/components/query-editor.svelte
@@ -170,12 +170,6 @@
 	// Context menu for copying cells
 	let contextCell = $state<{ value: unknown; column: string; row: Record<string, unknown> } | null>(null);
 
-	// Threshold for enabling virtualization (rows)
-	const VIRTUALIZATION_THRESHOLD = 100;
-	const shouldVirtualize = $derived(
-		(db.state.activeQueryTab?.results?.rows.length ?? 0) > VIRTUALIZATION_THRESHOLD
-	);
-
 	const handleCellRightClick = (value: unknown, column: string, row: Record<string, unknown>) => {
 		contextCell = { value, column, row };
 	};
@@ -437,79 +431,18 @@
                             </DropdownMenu.Root>
                         </div>
 
-                        {#if shouldVirtualize}
-                            <VirtualResultsTable
-                                columns={db.state.activeQueryTab.results.columns}
-                                rows={db.state.activeQueryTab.results.rows}
-                                isEditable={!!isEditable}
-                                onCellSave={handleCellSave}
-                                onRowDelete={confirmDeleteRow}
-                                {deletingRowIndex}
-                                onCopyCell={copyCell}
-                                onCopyRow={copyRowAsJSON}
-                                onCopyColumn={copyColumn}
-                                onCellRightClick={handleCellRightClick}
-                            />
-                        {:else}
-                            <ContextMenu.Root>
-                                <ContextMenu.Trigger class="flex-1 overflow-auto min-h-0 block">
-                                    <table class="w-full text-sm">
-                                        <thead class="sticky top-0 bg-muted border-b">
-                                            <tr>
-                                                {#if isEditable}
-                                                    <th class="px-2 py-2 w-8"></th>
-                                                {/if}
-                                                {#each db.state.activeQueryTab.results.columns as column}
-                                                    <th class="px-4 py-2 text-left font-medium">{column}</th>
-                                                {/each}
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {#each db.state.activeQueryTab.results.rows as row, i}
-                                                <tr class={["border-b hover:bg-muted/50", i % 2 === 0 && "bg-muted/20"]}>
-                                                    {#if isEditable}
-                                                        <td class="px-2 py-1">
-                                                            <RowActions
-                                                                onDelete={async () => confirmDeleteRow(i, row)}
-                                                                isDeleting={deletingRowIndex === i}
-                                                            />
-                                                        </td>
-                                                    {/if}
-                                                    {#each db.state.activeQueryTab.results.columns as column}
-                                                        <td
-                                                            class="px-4 py-2"
-                                                            oncontextmenu={() => handleCellRightClick(row[column], column, row)}
-                                                        >
-                                                            <EditableCell
-                                                                value={row[column]}
-                                                                isEditable={isEditable}
-                                                                onSave={(newValue) => handleCellSave(i, column, newValue)}
-                                                            />
-                                                        </td>
-                                                    {/each}
-                                                </tr>
-                                            {/each}
-                                        </tbody>
-                                    </table>
-                                </ContextMenu.Trigger>
-                                <ContextMenu.Portal>
-                                    <ContextMenu.Content class="w-48">
-                                        <ContextMenu.Item onclick={copyCell}>
-                                            <CopyIcon class="size-4 me-2" />
-                                            {m.query_copy_cell()}
-                                        </ContextMenu.Item>
-                                        <ContextMenu.Item onclick={copyRowAsJSON}>
-                                            <CopyIcon class="size-4 me-2" />
-                                            {m.query_copy_row()}
-                                        </ContextMenu.Item>
-                                        <ContextMenu.Item onclick={copyColumn}>
-                                            <CopyIcon class="size-4 me-2" />
-                                            {m.query_copy_column()}
-                                        </ContextMenu.Item>
-                                    </ContextMenu.Content>
-                                </ContextMenu.Portal>
-                            </ContextMenu.Root>
-                        {/if}
+                        <VirtualResultsTable
+                            columns={db.state.activeQueryTab.results.columns}
+                            rows={db.state.activeQueryTab.results.rows}
+                            isEditable={!!isEditable}
+                            onCellSave={handleCellSave}
+                            onRowDelete={confirmDeleteRow}
+                            {deletingRowIndex}
+                            onCopyCell={copyCell}
+                            onCopyRow={copyRowAsJSON}
+                            onCopyColumn={copyColumn}
+                            onCellRightClick={handleCellRightClick}
+                        />
 
                         <!-- Pagination Controls -->
                         {#if db.state.activeQueryTab.results.totalPages > 1}

--- a/src/lib/components/sidebar-left.svelte
+++ b/src/lib/components/sidebar-left.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { SvelteSet } from "svelte/reactivity";
 	import { getVersion } from "@tauri-apps/api/app";
 	import { useDatabase } from "$lib/hooks/database.svelte.js";
 	import { formatRelativeTime } from "$lib/utils.js";
@@ -20,24 +21,22 @@
 			version = v;
 		});
 	});
-	let expandedSchemas = $state<Set<string>>(new Set());
+	let expandedSchemas = new SvelteSet<string>();
 	let historyExpanded = $state(true);
 	let savedExpanded = $state(true);
 	let searchQuery = $state("");
 	let schemaSearchQuery = $state("");
 
 	const toggleSchema = (schemaName: string) => {
-		const newExpanded = new Set(expandedSchemas);
-		if (newExpanded.has(schemaName)) {
-			newExpanded.delete(schemaName);
+		if (expandedSchemas.has(schemaName)) {
+			expandedSchemas.delete(schemaName);
 		} else {
-			newExpanded.add(schemaName);
+			expandedSchemas.add(schemaName);
 		}
-		expandedSchemas = newExpanded;
 	};
 
 	// Filter and group tables by schema
-	const tablesBySchema = $derived(() => {
+	const tablesBySchema = $derived.by(() => {
 		const searchLower = schemaSearchQuery.toLowerCase();
 		const filtered = schemaSearchQuery
 			? db.state.activeSchema.filter(table =>
@@ -113,7 +112,7 @@
 					<SidebarGroupLabel>{db.state.activeConnection.name}</SidebarGroupLabel>
 					<SidebarGroupContent>
 						<SidebarMenu>
-							{#each [...tablesBySchema().entries()] as [schemaName, tables] (schemaName)}
+							{#each [...tablesBySchema.entries()] as [schemaName, tables] (schemaName)}
 								<Collapsible open={expandedSchemas.has(schemaName)} onOpenChange={() => toggleSchema(schemaName)}>
 									<SidebarMenuItem>
 										<CollapsibleTrigger>


### PR DESCRIPTION
## Summary
- Remove conditional virtualization threshold - always use VirtualResultsTable for consistent behavior
- Add resizable columns with drag-to-resize functionality for better data viewing
- Use CSS Grid for consistent column widths across header and body
- Make header sticky within scroll container for proper horizontal scroll sync
- Fix SvelteSet usage and $derived.by() syntax in sidebar-left

## Test plan
- [ ] Open a query tab and run a query with results
- [ ] Verify columns are resizable by dragging the column borders
- [ ] Verify horizontal scrolling keeps header and body in sync
- [ ] Verify the sidebar schema list expands/collapses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)