### PR TITLE
Fix window dragging in header

### DIFF
--- a/src/lib/components/app-header.svelte
+++ b/src/lib/components/app-header.svelte
@@ -77,7 +77,7 @@
         data-tauri-drag-region
         class="pl-18 h-(--header-height) flex w-full items-center gap-2 pr-2 justify-between"
     >
-        <div class="flex items-center gap-1 flex-1 min-w-0">
+        <div data-tauri-drag-region class="flex items-center gap-1 flex-1 min-w-0">
             <Button
                 class="size-8 shrink-0"
                 variant="ghost"


### PR DESCRIPTION
## Summary
- Add `data-tauri-drag-region` attribute to the child container div that fills the available horizontal space
- Fixes window dragging which broke after the dropdown menu was added in #30

## Root Cause
The parent div had `data-tauri-drag-region` but the child div with `flex-1` was receiving clicks on empty space, preventing the drag from triggering.

## Test plan
- [ ] Click and drag on empty space in the header to move the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)