### PR TITLE
Move Add Row button to table viewer and UX improvements

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -257,7 +257,10 @@
 
     // Register keyboard shortcuts
     onMount(() => {
-        shortcuts.registerHandler('newTab', () => db.queryTabs.add());
+        shortcuts.registerHandler('newTab', () => {
+            db.queryTabs.add();
+            db.ui.setActiveView("query");
+        });
         shortcuts.registerHandler('closeTab', closeCurrentTab);
         shortcuts.registerHandler('nextTab', () => {
             const idx = currentTabIndex();
@@ -509,7 +512,10 @@
                         size="icon"
                         variant="ghost"
                         class="size-7 shrink-0 [&_svg:not([class*='size-'])]:size-4"
-                        onclick={() => db.queryTabs.add()}
+                        onclick={() => {
+                            db.queryTabs.add();
+                            db.ui.setActiveView("query");
+                        }}
                     >
                         <PlusIcon />
                     </Button>


### PR DESCRIPTION
## Summary
- Move "Add Row" functionality from query editor to table viewer where it's more contextual
- Always show result tabs instead of only for multiple results
- Auto-switch to query view when creating new tabs

## Test plan
- [ ] Open a table in schema view, verify "Add Row" button appears for tables with primary keys
- [ ] Run a query, verify result tabs always show (even for single result)
- [ ] Press Cmd+T or click + button, verify it switches to query view

🤖 Generated with [Claude Code](https://claude.com/claude-code)