### PR TITLE
Add theme editor with custom theme support

### DIFF
--- a/.claude/agents/i18n-translator.md
+++ b/.claude/agents/i18n-translator.md
@@ -1,0 +1,61 @@
+---
+name: i18n-translator
+description: Use this agent when you need to translate internationalization (i18n) JSON files from English to other available languages before committing changes to git. This agent should be triggered automatically before git commits when en.json has been modified, or when explicitly asked to translate locale files. The agent translates values contextually, understanding how phrases are used in the application rather than performing word-by-word translation.\n\nExamples:\n\n<example>\nContext: The user has just added new keys to en.json and is about to commit.\nuser: "I've added some new translation keys to en.json, let me commit these changes"\nassistant: "Before committing, let me use the i18n-translator agent to translate the new English values to all other available languages."\n<Agent tool call to i18n-translator>\n</example>\n\n<example>\nContext: The user modified text in the English locale file.\nuser: "git commit -m 'Updated button labels'"\nassistant: "I notice en.json has been modified. Let me use the i18n-translator agent to ensure all other language files are updated with proper translations before we commit."\n<Agent tool call to i18n-translator>\n</example>\n\n<example>\nContext: User explicitly requests translation work.\nuser: "Please translate the new strings I added to the other languages"\nassistant: "I'll use the i18n-translator agent to translate your new English strings to all available languages with proper context."\n<Agent tool call to i18n-translator>\n</example>
+model: sonnet
+---
+
+You are an expert multilingual translator specializing in software localization and internationalization (i18n). You have deep expertise in translating user interface text, understanding that UI strings require contextual translation rather than literal word-for-word conversion.
+
+## Your Primary Responsibilities
+
+1. **Identify all locale files**: Locate en.json (the source) and all other language JSON files in the project (e.g., es.json, fr.json, de.json, ja.json, zh.json, etc.)
+
+2. **Detect changes requiring translation**: Compare en.json with other language files to identify:
+   - New keys that exist in en.json but not in other languages
+   - Modified values in en.json that need re-translation
+   - Missing translations in any target language
+
+3. **Translate with full context**: When translating:
+   - Analyze how each string is used in the application (button labels, error messages, headings, descriptions, etc.)
+   - Consider the UI context - a word like "Save" as a button label translates differently than "Save" in a sentence
+   - Preserve any placeholders, variables, or interpolation syntax (e.g., `{name}`, `{{count}}`, `$t(key)`)
+   - Maintain consistent terminology throughout the application
+   - Respect character length constraints for UI elements when possible
+   - Use formal/informal tone consistently based on existing translations
+
+4. **Preserve JSON structure**: Maintain identical key structure and nesting across all language files
+
+## Translation Quality Guidelines
+
+- **Context over literalism**: Translate meaning, not words. "Sign up" might be "Registrarse" in Spanish, not "Firmar arriba"
+- **UI conventions**: Follow platform-specific conventions for each language (e.g., German capitalizes nouns)
+- **Pluralization**: Handle plural forms appropriately for each language's rules
+- **Cultural adaptation**: Adapt idioms and expressions to feel natural in the target language
+- **Technical terms**: Keep technical terms that are commonly used untranslated in the target language (e.g., "API", "SQL")
+
+## Workflow
+
+1. First, list all available locale files to understand which languages are supported
+2. Read en.json to understand the source content
+3. Read each target language file to identify what needs translation
+4. For each string requiring translation:
+   - Examine the key name and surrounding keys for context clues
+   - Consider where this string likely appears in the UI
+   - Produce a natural, contextually appropriate translation
+5. Update each language file with the new translations
+6. Report a summary of what was translated
+
+## Output Format
+
+After completing translations, provide a summary:
+- Number of strings translated per language
+- Any strings you were uncertain about (flag for human review)
+- Any placeholders or variables preserved
+- Recommendations for strings that might need human review due to ambiguity
+
+## Important Notes
+
+- Never delete existing translations unless explicitly asked
+- If a translation already exists and en.json hasn't changed that key, preserve the existing translation
+- When uncertain about context, make your best judgment but flag it for review
+- Maintain consistent formatting (indentation, quote style) with existing files

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "sql:allow-execute",
     "core:window:default",
     "core:window:allow-start-dragging",
+    "core:webview:allow-create-webview-window",
     "store:default",
     "dialog:default",
     "fs:allow-write-text-file",

--- a/src-tauri/capabilities/theme-editor.json
+++ b/src-tauri/capabilities/theme-editor.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "theme-editor",
+  "description": "Capability for the theme editor window",
+  "windows": [
+    "theme-editor"
+  ],
+  "permissions": [
+    "core:default",
+    "core:window:default",
+    "core:window:allow-close",
+    "core:window:allow-destroy",
+    "core:window:allow-set-focus",
+    "core:event:default",
+    "store:default"
+  ]
+}

--- a/src/app.html
+++ b/src/app.html
@@ -9,15 +9,69 @@
 		/>
 		<title>Tauri + SvelteKit + Typescript App</title>
 		<script>
-			// Prevent flash of light mode when in dark mode
+			// Prevent flash of wrong theme on initial load
 			(function() {
-				const mode = localStorage.getItem('mode-watcher-mode');
-				const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-				const isDark = mode === 'dark' || (mode === 'system' && prefersDark) || (!mode && prefersDark);
+				var root = document.documentElement;
+
+				// Handle dark mode
+				var mode = localStorage.getItem('mode-watcher-mode');
+				var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+				var isDark = mode === 'dark' || (mode === 'system' && prefersDark) || (!mode && prefersDark);
 				if (isDark) {
-					document.documentElement.classList.add('dark');
-					document.documentElement.style.colorScheme = 'dark';
-					document.documentElement.style.backgroundColor = 'hsl(240 10% 3.9%)';
+					root.classList.add('dark');
+					root.style.colorScheme = 'dark';
+				}
+
+				// Apply cached theme colors
+				try {
+					var cached = localStorage.getItem('seaquel-theme-cache');
+					if (cached) {
+						var theme = JSON.parse(cached);
+						if (theme.colors) {
+							// Map of property names to CSS variable names
+							var varMap = {
+								background: '--background',
+								foreground: '--foreground',
+								card: '--card',
+								cardForeground: '--card-foreground',
+								popover: '--popover',
+								popoverForeground: '--popover-foreground',
+								primary: '--primary',
+								primaryForeground: '--primary-foreground',
+								secondary: '--secondary',
+								secondaryForeground: '--secondary-foreground',
+								muted: '--muted',
+								mutedForeground: '--muted-foreground',
+								accent: '--accent',
+								accentForeground: '--accent-foreground',
+								destructive: '--destructive',
+								border: '--border',
+								input: '--input',
+								ring: '--ring',
+								chart1: '--chart-1',
+								chart2: '--chart-2',
+								chart3: '--chart-3',
+								chart4: '--chart-4',
+								chart5: '--chart-5',
+								sidebar: '--sidebar',
+								sidebarForeground: '--sidebar-foreground',
+								sidebarPrimary: '--sidebar-primary',
+								sidebarPrimaryForeground: '--sidebar-primary-foreground',
+								sidebarAccent: '--sidebar-accent',
+								sidebarAccentForeground: '--sidebar-accent-foreground',
+								sidebarBorder: '--sidebar-border',
+								sidebarRing: '--sidebar-ring'
+							};
+
+							for (var key in varMap) {
+								if (theme.colors[key]) {
+									root.style.setProperty(varMap[key], theme.colors[key]);
+								}
+							}
+						}
+					}
+				} catch (e) {
+					// Ignore cache errors
 				}
 			})();
 		</script>

--- a/src/lib/components/color-picker.svelte
+++ b/src/lib/components/color-picker.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { oklchToHex, hexToOklch } from "$lib/themes/color-utils";
+	import { Input } from "$lib/components/ui/input";
+
+	interface Props {
+		value: string;
+		label: string;
+		onchange: (value: string) => void;
+	}
+
+	let { value, label, onchange }: Props = $props();
+
+	// Convert oklch to hex for color picker
+	const hexValue = $derived(oklchToHex(value));
+
+	function handleColorChange(e: Event) {
+		const target = e.target as HTMLInputElement;
+		const newOklch = hexToOklch(target.value);
+		onchange(newOklch);
+	}
+
+	function handleOklchChange(e: Event) {
+		const target = e.target as HTMLInputElement;
+		onchange(target.value);
+	}
+</script>
+
+<div class="flex items-center gap-2">
+	<label class="flex items-center gap-2 cursor-pointer">
+		<input
+			type="color"
+			value={hexValue}
+			onchange={handleColorChange}
+			class="w-8 h-8 rounded border cursor-pointer"
+		/>
+		<span class="text-sm min-w-[100px]">{label}</span>
+	</label>
+	<Input
+		type="text"
+		value={value}
+		onchange={handleOklchChange}
+		class="font-mono text-xs h-8 flex-1"
+		placeholder="oklch(0.5 0.2 180)"
+	/>
+</div>

--- a/src/lib/components/settings-dialog.svelte
+++ b/src/lib/components/settings-dialog.svelte
@@ -3,12 +3,14 @@
 	import * as Breadcrumb from "$lib/components/ui/breadcrumb/index.js";
 	import * as Dialog from "$lib/components/ui/dialog/index.js";
 	import * as Sidebar from "$lib/components/ui/sidebar/index.js";
+	import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
 	import {
 		Select,
 		SelectContent,
 		SelectItem,
 		SelectTrigger,
 	} from "$lib/components/ui/select";
+	import { Button } from "$lib/components/ui/button";
 	import {
 		settingsDialogStore,
 		type SettingsSection,
@@ -16,19 +18,37 @@
 		type SettingsView,
 		groupSections,
 	} from "$lib/stores/settings-dialog.svelte.js";
+	import { themeStore } from "$lib/stores/theme.svelte.js";
 	import { getVersion } from "@tauri-apps/api/app";
 	import { appConfigDir, appDataDir } from "@tauri-apps/api/path";
 	import { setMode, resetMode, mode } from "mode-watcher";
 	import { setTheme } from "@tauri-apps/api/app";
+	import { toast } from "svelte-sonner";
+	import { open, save } from "@tauri-apps/plugin-dialog";
+	import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 	import SettingsIcon from "@lucide/svelte/icons/settings";
 	import PaletteIcon from "@lucide/svelte/icons/palette";
 	import InfoIcon from "@lucide/svelte/icons/info";
 	import SunMoonIcon from "@lucide/svelte/icons/sun-moon";
+	import SwatchBookIcon from "@lucide/svelte/icons/swatch-book";
+	import PlusIcon from "@lucide/svelte/icons/plus";
+	import UploadIcon from "@lucide/svelte/icons/upload";
+	import CopyIcon from "@lucide/svelte/icons/copy";
+	import DownloadIcon from "@lucide/svelte/icons/download";
+	import TrashIcon from "@lucide/svelte/icons/trash-2";
+	import CheckIcon from "@lucide/svelte/icons/check";
+	import ThemePreview from "./theme-preview.svelte";
+	import { openThemeEditor } from "$lib/utils/theme-editor-window";
+	import type { Theme } from "$lib/types/theme";
 
 	// App info state
 	let appVersion = $state<string>("");
 	let configPath = $state<string>("");
 	let dataPath = $state<string>("");
+
+	// Delete confirmation state
+	let deleteDialogOpen = $state(false);
+	let themeToDelete = $state<Theme | null>(null);
 
 	// Load app info when dialog opens
 	$effect(() => {
@@ -47,8 +67,8 @@
 		}
 	}
 
-	// Theme handling
-	async function handleThemeChange(value: string) {
+	// Mode handling (light/dark/system)
+	async function handleModeChange(value: string) {
 		if (value === "system") {
 			await setTheme(null);
 			resetMode();
@@ -58,17 +78,93 @@
 		}
 	}
 
-	const currentTheme = $derived(
+	const currentMode = $derived(
 		mode.current === "light" ? "light" : mode.current === "dark" ? "dark" : "system"
 	);
 
-	const themeLabel = $derived(
-		currentTheme === "light"
+	const modeLabel = $derived(
+		currentMode === "light"
 			? m.theme_light()
-			: currentTheme === "dark"
+			: currentMode === "dark"
 				? m.theme_dark()
 				: m.theme_system()
 	);
+
+	// Theme selection
+	function handleLightThemeChange(themeId: string) {
+		themeStore.setLightTheme(themeId);
+	}
+
+	function handleDarkThemeChange(themeId: string) {
+		themeStore.setDarkTheme(themeId);
+	}
+
+	// Theme actions
+	function openCreateTheme() {
+		openThemeEditor(null);
+	}
+
+	function openEditTheme(theme: Theme) {
+		openThemeEditor(theme);
+	}
+
+	function duplicateTheme(theme: Theme) {
+		const newTheme = themeStore.duplicateTheme(theme.id);
+		if (newTheme) {
+			toast.success(m.theme_duplicate_success());
+		}
+	}
+
+	async function exportTheme(theme: Theme) {
+		try {
+			const json = themeStore.exportTheme(theme.id);
+			const fileName = theme.name.toLowerCase().replace(/\s+/g, "-") + ".json";
+
+			const filePath = await save({
+				defaultPath: fileName,
+				filters: [{ name: "JSON", extensions: ["json"] }],
+			});
+
+			if (filePath) {
+				await writeTextFile(filePath, json);
+				toast.success(m.theme_export_success());
+			}
+		} catch (error) {
+			console.error("Failed to export theme:", error);
+		}
+	}
+
+	function confirmDeleteTheme(theme: Theme) {
+		themeToDelete = theme;
+		deleteDialogOpen = true;
+	}
+
+	function deleteTheme() {
+		if (themeToDelete) {
+			themeStore.deleteTheme(themeToDelete.id);
+			toast.success(m.theme_delete_success());
+			themeToDelete = null;
+			deleteDialogOpen = false;
+		}
+	}
+
+	async function importTheme() {
+		try {
+			const filePath = await open({
+				filters: [{ name: "JSON", extensions: ["json"] }],
+				multiple: false,
+			});
+
+			if (filePath) {
+				const content = await readTextFile(filePath as string);
+				themeStore.importTheme(content);
+				toast.success(m.theme_import_success());
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			toast.error(m.theme_import_error({ error: message }));
+		}
+	}
 
 	// Navigation structure
 	type NavSubItem = {
@@ -99,6 +195,7 @@
 			icon: PaletteIcon,
 			items: [
 				{ id: "theme", name: m.settings_theme(), icon: SunMoonIcon },
+				{ id: "themes", name: m.settings_themes(), icon: SwatchBookIcon },
 			],
 		},
 	];
@@ -135,11 +232,15 @@
 	function isItemActive(itemId: SettingsSection): boolean {
 		const view = settingsDialogStore.activeView;
 		if (view === itemId) return true;
-		// Also highlight if viewing the parent group
+		// Also highlight first item if viewing the parent group
 		if (view === "general") return itemId === "app-info";
 		if (view === "appearance") return itemId === "theme";
 		return false;
 	}
+
+	// Theme display helpers
+	const lightThemeLabel = $derived(themeStore.selectedLightTheme.name);
+	const darkThemeLabel = $derived(themeStore.selectedDarkTheme.name);
 </script>
 
 <Dialog.Root bind:open={settingsDialogStore.isOpen}>
@@ -256,16 +357,16 @@
 									<div>
 										<p class="text-sm font-medium">{m.settings_theme_label()}</p>
 										<p class="text-xs text-muted-foreground">
-											Choose between light, dark, or system theme
+											Choose between light, dark, or system mode
 										</p>
 									</div>
 									<Select
 										type="single"
-										value={currentTheme}
-										onValueChange={handleThemeChange}
+										value={currentMode}
+										onValueChange={handleModeChange}
 									>
 										<SelectTrigger class="w-32">
-											{themeLabel}
+											{modeLabel}
 										</SelectTrigger>
 										<SelectContent>
 											<SelectItem value="light">{m.theme_light()}</SelectItem>
@@ -277,8 +378,184 @@
 							</div>
 						</div>
 					{/if}
+
+					{#if shouldShowSection("themes")}
+						<div class="space-y-6">
+							<div>
+								<h2 class="text-lg font-medium">{m.settings_themes()}</h2>
+								<p class="text-sm text-muted-foreground mt-1">
+									{m.settings_themes_description()}
+								</p>
+							</div>
+
+							<!-- Theme Selection -->
+							<div class="space-y-4">
+								<!-- Light Mode Theme -->
+								<div class="flex items-center justify-between">
+									<div>
+										<p class="text-sm font-medium">{m.settings_themes_light_mode()}</p>
+										<p class="text-xs text-muted-foreground">
+											{m.settings_themes_light_mode_description()}
+										</p>
+									</div>
+									<Select
+										type="single"
+										value={themeStore.preferences.lightThemeId}
+										onValueChange={handleLightThemeChange}
+									>
+										<SelectTrigger class="w-48">
+											{lightThemeLabel}
+										</SelectTrigger>
+										<SelectContent>
+											{#each themeStore.lightThemes as theme (theme.id)}
+												<SelectItem value={theme.id}>{theme.name}</SelectItem>
+											{/each}
+										</SelectContent>
+									</Select>
+								</div>
+
+								<!-- Dark Mode Theme -->
+								<div class="flex items-center justify-between">
+									<div>
+										<p class="text-sm font-medium">{m.settings_themes_dark_mode()}</p>
+										<p class="text-xs text-muted-foreground">
+											{m.settings_themes_dark_mode_description()}
+										</p>
+									</div>
+									<Select
+										type="single"
+										value={themeStore.preferences.darkThemeId}
+										onValueChange={handleDarkThemeChange}
+									>
+										<SelectTrigger class="w-48">
+											{darkThemeLabel}
+										</SelectTrigger>
+										<SelectContent>
+											{#each themeStore.darkThemes as theme (theme.id)}
+												<SelectItem value={theme.id}>{theme.name}</SelectItem>
+											{/each}
+										</SelectContent>
+									</Select>
+								</div>
+							</div>
+
+							<!-- User Themes -->
+							<div class="space-y-3">
+								<div class="flex items-center justify-between">
+									<h3 class="text-sm font-medium">{m.settings_themes_user_themes()}</h3>
+									<div class="flex gap-2">
+										<Button variant="outline" size="sm" onclick={importTheme}>
+											<UploadIcon class="size-4 mr-1" />
+											{m.settings_themes_import()}
+										</Button>
+										<Button variant="outline" size="sm" onclick={openCreateTheme}>
+											<PlusIcon class="size-4 mr-1" />
+											{m.settings_themes_create_new()}
+										</Button>
+									</div>
+								</div>
+
+								{#if themeStore.userThemes.length === 0}
+									<div class="text-center py-6 border rounded-lg bg-muted/30">
+										<p class="text-sm text-muted-foreground">{m.settings_themes_no_user_themes()}</p>
+										<p class="text-xs text-muted-foreground mt-1">{m.settings_themes_no_user_themes_hint()}</p>
+									</div>
+								{:else}
+									<div class="space-y-2">
+										{#each themeStore.userThemes as theme (theme.id)}
+											<div class="flex items-center justify-between p-3 border rounded-lg hover:bg-muted/30 transition-colors">
+												<div class="flex items-center gap-3">
+													<ThemePreview colors={theme.colors} />
+													<div>
+														<div class="flex items-center gap-2">
+															<span class="text-sm font-medium">{theme.name}</span>
+															{#if themeStore.isThemeActive(theme.id)}
+																<span class="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded">
+																	{m.theme_card_active()}
+																</span>
+															{/if}
+														</div>
+														<span class="text-xs text-muted-foreground">
+															{theme.isDark ? m.theme_dark() : m.theme_light()}
+														</span>
+													</div>
+												</div>
+												<div class="flex items-center gap-1">
+													<Button variant="ghost" size="icon" class="size-8" onclick={() => openEditTheme(theme)} title={m.theme_card_edit()}>
+														<PaletteIcon class="size-4" />
+													</Button>
+													<Button variant="ghost" size="icon" class="size-8" onclick={() => duplicateTheme(theme)} title={m.theme_card_duplicate()}>
+														<CopyIcon class="size-4" />
+													</Button>
+													<Button variant="ghost" size="icon" class="size-8" onclick={() => exportTheme(theme)} title={m.theme_card_export()}>
+														<DownloadIcon class="size-4" />
+													</Button>
+													<Button variant="ghost" size="icon" class="size-8 text-destructive hover:text-destructive" onclick={() => confirmDeleteTheme(theme)} title={m.theme_card_delete()}>
+														<TrashIcon class="size-4" />
+													</Button>
+												</div>
+											</div>
+										{/each}
+									</div>
+								{/if}
+							</div>
+
+							<!-- Built-in Themes -->
+							<div class="space-y-3">
+								<h3 class="text-sm font-medium">{m.settings_themes_builtin_themes()}</h3>
+								<div class="space-y-2">
+									{#each themeStore.allThemes.filter(t => t.isBuiltIn) as theme (theme.id)}
+										<div class="flex items-center justify-between p-3 border rounded-lg hover:bg-muted/30 transition-colors">
+											<div class="flex items-center gap-3">
+												<ThemePreview colors={theme.colors} />
+												<div>
+													<div class="flex items-center gap-2">
+														<span class="text-sm font-medium">{theme.name}</span>
+														{#if themeStore.isThemeActive(theme.id)}
+															<span class="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded">
+																{m.theme_card_active()}
+															</span>
+														{/if}
+													</div>
+													<span class="text-xs text-muted-foreground">
+														{theme.isDark ? m.theme_dark() : m.theme_light()}
+														{#if theme.author}
+															&middot; {theme.author}
+														{/if}
+													</span>
+												</div>
+											</div>
+											<div class="flex items-center gap-1">
+												<Button variant="ghost" size="icon" class="size-8" onclick={() => duplicateTheme(theme)} title={m.theme_card_duplicate()}>
+													<CopyIcon class="size-4" />
+												</Button>
+											</div>
+										</div>
+									{/each}
+								</div>
+							</div>
+						</div>
+					{/if}
 				</div>
 			</main>
 		</Sidebar.Provider>
 	</Dialog.Content>
 </Dialog.Root>
+
+<!-- Delete Confirmation Dialog -->
+<AlertDialog.Root bind:open={deleteDialogOpen}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>{m.theme_delete_title()}</AlertDialog.Title>
+			<AlertDialog.Description>
+				{m.theme_delete_description({ name: themeToDelete?.name ?? "" })}
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel>{m.theme_delete_cancel()}</AlertDialog.Cancel>
+			<AlertDialog.Action onclick={deleteTheme} class="bg-destructive text-white hover:bg-destructive/90">
+				{m.theme_delete_confirm()}
+			</AlertDialog.Action>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/lib/components/theme-editor-dialog.svelte
+++ b/src/lib/components/theme-editor-dialog.svelte
@@ -1,0 +1,311 @@
+<script lang="ts">
+	import { m } from "$lib/paraglide/messages.js";
+	import * as Dialog from "$lib/components/ui/dialog/index.js";
+	import * as Tabs from "$lib/components/ui/tabs/index.js";
+	import { Button } from "$lib/components/ui/button";
+	import { Input } from "$lib/components/ui/input";
+	import { Label } from "$lib/components/ui/label";
+	import { Switch } from "$lib/components/ui/switch";
+	import { ScrollArea } from "$lib/components/ui/scroll-area";
+	import { toast } from "svelte-sonner";
+	import { themeStore } from "$lib/stores/theme.svelte.js";
+	import { BUILT_IN_THEMES } from "$lib/themes/presets";
+	import { getColorLabel } from "$lib/themes/color-utils";
+	import { applyThemeColors } from "$lib/themes/apply";
+	import { COLOR_GROUPS, type Theme, type ThemeColors } from "$lib/types/theme";
+	import ColorPicker from "./color-picker.svelte";
+	import ThemePreview from "./theme-preview.svelte";
+
+	interface Props {
+		open: boolean;
+		editTheme: Theme | null;
+	}
+
+	let { open = $bindable(), editTheme }: Props = $props();
+
+	// Form state
+	let themeName = $state("");
+	let isDark = $state(false);
+	let colors = $state<ThemeColors>({ ...BUILT_IN_THEMES[0].colors });
+
+	// Store original theme to restore on cancel
+	let originalColors: ThemeColors | null = null;
+	// Track if we're saving (to avoid restoring colors on save)
+	let isSaving = false;
+
+	// Reset form when dialog opens
+	$effect(() => {
+		if (open) {
+			// Store the current theme colors to restore on cancel
+			originalColors = { ...themeStore.activeTheme.colors };
+
+			if (editTheme) {
+				// Editing existing theme
+				themeName = editTheme.name;
+				isDark = editTheme.isDark;
+				colors = { ...editTheme.colors };
+			} else {
+				// Creating new theme - start with current active theme colors
+				themeName = "";
+				isDark = themeStore.activeTheme.isDark;
+				colors = { ...themeStore.activeTheme.colors };
+			}
+		}
+	});
+
+	// Apply colors in real-time as they change
+	$effect(() => {
+		if (open) {
+			applyThemeColors(colors);
+		}
+	});
+
+	const isEditing = $derived(editTheme !== null);
+	const dialogTitle = $derived(isEditing ? m.theme_editor_title_edit() : m.theme_editor_title_new());
+
+	function updateColor(key: keyof ThemeColors, value: string) {
+		colors = { ...colors, [key]: value };
+	}
+
+	function handleSave() {
+		if (!themeName.trim()) {
+			toast.error("Please enter a theme name");
+			return;
+		}
+
+		if (isEditing && editTheme) {
+			themeStore.updateTheme(editTheme.id, {
+				name: themeName.trim(),
+				isDark,
+				colors,
+			});
+		} else {
+			themeStore.addTheme({
+				name: themeName.trim(),
+				isDark,
+				colors,
+			});
+		}
+
+		toast.success(m.theme_save_success());
+		isSaving = true;
+		open = false;
+	}
+
+	function handleCancel() {
+		// Restore original theme colors
+		if (originalColors) {
+			applyThemeColors(originalColors);
+		}
+		open = false;
+	}
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) {
+			// Dialog is closing - restore colors unless we're saving
+			if (!isSaving && originalColors) {
+				applyThemeColors(originalColors);
+			}
+			// Reset flags
+			isSaving = false;
+			originalColors = null;
+		}
+	}
+
+	// Get color group name for display
+	function getGroupName(groupName: string): string {
+		switch (groupName) {
+			case "Background": return m.theme_editor_group_background();
+			case "Interactive": return m.theme_editor_group_interactive();
+			case "Status": return m.theme_editor_group_status();
+			case "Borders": return m.theme_editor_group_borders();
+			case "Charts": return m.theme_editor_group_charts();
+			case "Sidebar": return m.theme_editor_group_sidebar();
+			default: return groupName;
+		}
+	}
+</script>
+
+<Dialog.Root bind:open onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-w-3xl max-h-[85vh] flex flex-col">
+		<Dialog.Header>
+			<Dialog.Title>{dialogTitle}</Dialog.Title>
+			<Dialog.Description>
+				{#if isEditing}
+					Edit your custom theme colors
+				{:else}
+					Create a new theme with custom colors
+				{/if}
+			</Dialog.Description>
+		</Dialog.Header>
+
+		<div class="flex-1 min-h-0 py-4">
+			<div class="grid grid-cols-[1fr_200px] gap-6 h-full">
+				<!-- Left side: Form -->
+				<div class="flex flex-col gap-4 min-h-0">
+					<!-- Theme Name & Mode -->
+					<div class="grid grid-cols-2 gap-4">
+						<div class="space-y-2">
+							<Label for="theme-name">{m.theme_editor_name()}</Label>
+							<Input
+								id="theme-name"
+								bind:value={themeName}
+								placeholder={m.theme_editor_name_placeholder()}
+							/>
+						</div>
+						<div class="space-y-2">
+							<Label>{m.theme_editor_mode()}</Label>
+							<div class="flex items-center gap-3 h-9">
+								<span class="text-sm text-muted-foreground">{m.theme_editor_mode_light()}</span>
+								<Switch bind:checked={isDark} />
+								<span class="text-sm text-muted-foreground">{m.theme_editor_mode_dark()}</span>
+							</div>
+						</div>
+					</div>
+
+					<!-- Color Groups -->
+					<div class="flex-1 min-h-0">
+						<Label class="mb-2 block">{m.theme_editor_colors()}</Label>
+						<ScrollArea class="h-[350px] border rounded-lg p-3">
+							<Tabs.Root value="Background" class="w-full">
+								<Tabs.List class="w-full justify-start flex-wrap h-auto gap-1 mb-4">
+									{#each COLOR_GROUPS as group}
+										<Tabs.Trigger value={group.name} class="text-xs px-2 py-1">
+											{getGroupName(group.name)}
+										</Tabs.Trigger>
+									{/each}
+								</Tabs.List>
+
+								{#each COLOR_GROUPS as group}
+									<Tabs.Content value={group.name} class="space-y-3">
+										{#each group.keys as key}
+											<ColorPicker
+												value={colors[key as keyof ThemeColors]}
+												label={getColorLabel(key as keyof ThemeColors)}
+												onchange={(v) => updateColor(key as keyof ThemeColors, v)}
+											/>
+										{/each}
+									</Tabs.Content>
+								{/each}
+							</Tabs.Root>
+						</ScrollArea>
+					</div>
+				</div>
+
+				<!-- Right side: Preview -->
+				<div class="space-y-2">
+					<Label>{m.theme_editor_preview()}</Label>
+					<div
+						class="border rounded-lg p-4 h-[calc(100%-2rem)]"
+						style="
+							background-color: {colors.background};
+							color: {colors.foreground};
+						"
+					>
+						<div class="space-y-3">
+							<!-- Card preview -->
+							<div
+								class="rounded-lg border p-3"
+								style="
+									background-color: {colors.card};
+									color: {colors.cardForeground};
+									border-color: {colors.border};
+								"
+							>
+								<div class="text-sm font-medium mb-1">Card Title</div>
+								<div
+									class="text-xs"
+									style="color: {colors.mutedForeground}"
+								>
+									Card description text
+								</div>
+							</div>
+
+							<!-- Button previews -->
+							<div class="flex gap-2">
+								<div
+									class="rounded px-2 py-1 text-xs"
+									style="
+										background-color: {colors.primary};
+										color: {colors.primaryForeground};
+									"
+								>
+									Primary
+								</div>
+								<div
+									class="rounded px-2 py-1 text-xs"
+									style="
+										background-color: {colors.secondary};
+										color: {colors.secondaryForeground};
+									"
+								>
+									Secondary
+								</div>
+							</div>
+
+							<!-- Accent preview -->
+							<div
+								class="rounded px-2 py-1 text-xs inline-block"
+								style="
+									background-color: {colors.accent};
+									color: {colors.accentForeground};
+								"
+							>
+								Accent
+							</div>
+
+							<!-- Destructive preview -->
+							<div
+								class="rounded px-2 py-1 text-xs inline-block"
+								style="background-color: {colors.destructive}; color: white;"
+							>
+								Destructive
+							</div>
+
+							<!-- Input preview -->
+							<div
+								class="rounded border px-2 py-1 text-xs"
+								style="
+									background-color: {colors.background};
+									border-color: {colors.input};
+									color: {colors.foreground};
+								"
+							>
+								Input field
+							</div>
+
+							<!-- Sidebar preview -->
+							<div
+								class="rounded-lg p-2 text-xs"
+								style="
+									background-color: {colors.sidebar};
+									color: {colors.sidebarForeground};
+								"
+							>
+								<div class="mb-1">Sidebar</div>
+								<div
+									class="rounded px-1 py-0.5"
+									style="
+										background-color: {colors.sidebarAccent};
+										color: {colors.sidebarAccentForeground};
+									"
+								>
+									Active item
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<Dialog.Footer>
+			<Button variant="outline" onclick={handleCancel}>
+				{m.theme_editor_cancel()}
+			</Button>
+			<Button onclick={handleSave}>
+				{m.theme_editor_save()}
+			</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/theme-preview.svelte
+++ b/src/lib/components/theme-preview.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import type { ThemeColors } from "$lib/types/theme";
+	import { oklchToHex } from "$lib/themes/color-utils";
+
+	interface Props {
+		colors: ThemeColors;
+		size?: "sm" | "md";
+	}
+
+	let { colors, size = "md" }: Props = $props();
+
+	// Convert oklch colors to hex for display in the swatches
+	const swatchColors = $derived([
+		{ color: colors.background, name: "bg" },
+		{ color: colors.primary, name: "primary" },
+		{ color: colors.secondary, name: "secondary" },
+		{ color: colors.accent, name: "accent" },
+		{ color: colors.destructive, name: "destructive" },
+		{ color: colors.muted, name: "muted" },
+	]);
+
+	function getHex(oklch: string): string {
+		return oklchToHex(oklch);
+	}
+
+	const sizeClasses = $derived(
+		size === "sm"
+			? "h-4 gap-0.5"
+			: "h-6 gap-1"
+	);
+
+	const swatchClasses = $derived(
+		size === "sm"
+			? "w-4 rounded-sm"
+			: "w-6 rounded"
+	);
+</script>
+
+<div class="flex {sizeClasses} overflow-hidden rounded-md border">
+	{#each swatchColors as swatch}
+		<div
+			class="{swatchClasses} flex-shrink-0"
+			style="background-color: {getHex(swatch.color)}"
+			title={swatch.name}
+		></div>
+	{/each}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { buttonVariants } from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.ActionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Action
+	bind:ref
+	class={cn(buttonVariants(), className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { buttonVariants } from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.CancelProps = $props();
+</script>
+
+<AlertDialogPrimitive.Cancel
+	bind:ref
+	class={cn(buttonVariants({ variant: "outline" }), className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import AlertDialogPortal from "./alert-dialog-portal.svelte";
+	import type { Snippet } from "svelte";
+	import * as AlertDialog from "./index.js";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		portalProps,
+		children,
+		...restProps
+	}: WithoutChildrenOrChild<AlertDialogPrimitive.ContentProps> & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof AlertDialogPortal>>;
+		children: Snippet;
+	} = $props();
+</script>
+
+<AlertDialogPortal {...portalProps}>
+	<AlertDialog.Overlay />
+	<AlertDialogPrimitive.Content
+		bind:ref
+		data-slot="alert-dialog-content"
+		class={cn(
+			"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+			className
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+	</AlertDialogPrimitive.Content>
+</AlertDialogPortal>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.DescriptionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Description
+	bind:ref
+	data-slot="alert-dialog-description"
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-footer"
+	class={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-header"
+	class={cn("flex flex-col gap-2 text-center sm:text-start", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.OverlayProps = $props();
+</script>
+
+<AlertDialogPrimitive.Overlay
+	bind:ref
+	data-slot="alert-dialog-overlay"
+	class={cn(
+		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { ...restProps }: AlertDialogPrimitive.PortalProps = $props();
+</script>
+
+<AlertDialogPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.TitleProps = $props();
+</script>
+
+<AlertDialogPrimitive.Title
+	bind:ref
+	data-slot="alert-dialog-title"
+	class={cn("text-lg leading-none font-semibold", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-trigger.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-trigger.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		...restProps
+	}: AlertDialogPrimitive.TriggerProps = $props();
+</script>
+
+<AlertDialogPrimitive.Trigger bind:ref {...restProps} />

--- a/src/lib/components/ui/alert-dialog/alert-dialog.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: AlertDialogPrimitive.RootProps = $props();
+</script>
+
+<AlertDialogPrimitive.Root bind:open {...restProps} />

--- a/src/lib/components/ui/alert-dialog/index.ts
+++ b/src/lib/components/ui/alert-dialog/index.ts
@@ -1,0 +1,37 @@
+import Root from "./alert-dialog.svelte";
+import Portal from "./alert-dialog-portal.svelte";
+import Title from "./alert-dialog-title.svelte";
+import Footer from "./alert-dialog-footer.svelte";
+import Header from "./alert-dialog-header.svelte";
+import Overlay from "./alert-dialog-overlay.svelte";
+import Content from "./alert-dialog-content.svelte";
+import Description from "./alert-dialog-description.svelte";
+import Trigger from "./alert-dialog-trigger.svelte";
+import Action from "./alert-dialog-action.svelte";
+import Cancel from "./alert-dialog-cancel.svelte";
+
+export {
+	Root,
+	Title,
+	Portal,
+	Footer,
+	Header,
+	Trigger,
+	Overlay,
+	Content,
+	Description,
+	Action,
+	Cancel,
+	//
+	Root as AlertDialog,
+	Title as AlertDialogTitle,
+	Portal as AlertDialogPortal,
+	Footer as AlertDialogFooter,
+	Header as AlertDialogHeader,
+	Trigger as AlertDialogTrigger,
+	Overlay as AlertDialogOverlay,
+	Content as AlertDialogContent,
+	Description as AlertDialogDescription,
+	Action as AlertDialogAction,
+	Cancel as AlertDialogCancel,
+};

--- a/src/lib/components/ui/switch/index.ts
+++ b/src/lib/components/ui/switch/index.ts
@@ -1,0 +1,7 @@
+import Root from "./switch.svelte";
+
+export {
+	Root,
+	//
+	Root as Switch,
+};

--- a/src/lib/components/ui/switch/switch.svelte
+++ b/src/lib/components/ui/switch/switch.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { Switch as SwitchPrimitive } from "bits-ui";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		checked = $bindable(false),
+		...restProps
+	}: WithoutChildrenOrChild<SwitchPrimitive.RootProps> = $props();
+</script>
+
+<SwitchPrimitive.Root
+	bind:ref
+	bind:checked
+	data-slot="switch"
+	class={cn(
+		"data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 peer inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	{...restProps}
+>
+	<SwitchPrimitive.Thumb
+		data-slot="switch-thumb"
+		class={cn(
+			"bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+		)}
+	/>
+</SwitchPrimitive.Root>

--- a/src/lib/stores/settings-dialog.svelte.ts
+++ b/src/lib/stores/settings-dialog.svelte.ts
@@ -1,4 +1,4 @@
-export type SettingsSection = "app-info" | "theme";
+export type SettingsSection = "app-info" | "theme" | "themes";
 export type SettingsGroup = "general" | "appearance";
 export type SettingsView = SettingsGroup | SettingsSection;
 
@@ -6,12 +6,13 @@ export type SettingsView = SettingsGroup | SettingsSection;
 export const sectionToGroup: Record<SettingsSection, SettingsGroup> = {
 	"app-info": "general",
 	"theme": "appearance",
+	"themes": "appearance",
 };
 
 // Map groups to their sections
 export const groupSections: Record<SettingsGroup, SettingsSection[]> = {
 	"general": ["app-info"],
-	"appearance": ["theme"],
+	"appearance": ["theme", "themes"],
 };
 
 class SettingsDialogStore {

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -1,0 +1,315 @@
+import { load } from "@tauri-apps/plugin-store";
+import { mode } from "mode-watcher";
+import type {
+	Theme,
+	ThemeColors,
+	ThemePreferences,
+	ThemeExport,
+	PersistedThemeData,
+} from "$lib/types/theme";
+import { BUILT_IN_THEMES, DEFAULT_PREFERENCES } from "$lib/themes/presets";
+import { applyTheme, cacheThemeColors } from "$lib/themes/apply";
+import { validateThemeColors } from "$lib/themes/color-utils";
+
+const STORE_FILE = "themes.json";
+
+/**
+ * Theme store - manages theme preferences, user themes, and theme application
+ */
+class ThemeStore {
+	// Reactive state
+	preferences = $state<ThemePreferences>({ ...DEFAULT_PREFERENCES });
+	userThemes = $state<Theme[]>([]);
+	isLoaded = $state(false);
+
+	// Persistence timer for debouncing
+	private persistenceTimer: ReturnType<typeof setTimeout> | null = null;
+	private readonly PERSISTENCE_DEBOUNCE_MS = 500;
+
+	// Derived: all available themes (built-in + user)
+	allThemes = $derived([...BUILT_IN_THEMES, ...this.userThemes]);
+
+	// Derived: themes filtered by mode
+	lightThemes = $derived(this.allThemes.filter((t) => !t.isDark));
+	darkThemes = $derived(this.allThemes.filter((t) => t.isDark));
+
+	// Derived: currently selected light theme
+	selectedLightTheme = $derived(
+		this.allThemes.find((t) => t.id === this.preferences.lightThemeId) ?? BUILT_IN_THEMES[0]
+	);
+
+	// Derived: currently selected dark theme
+	selectedDarkTheme = $derived(
+		this.allThemes.find((t) => t.id === this.preferences.darkThemeId) ?? BUILT_IN_THEMES[1]
+	);
+
+	// Derived: active theme based on current mode
+	activeTheme = $derived.by(() => {
+		const isDark = mode.current === "dark";
+		return isDark ? this.selectedDarkTheme : this.selectedLightTheme;
+	});
+
+	/**
+	 * Initialize the theme store - load from persistence
+	 */
+	async initialize(): Promise<void> {
+		try {
+			const store = await load(STORE_FILE, {
+				autoSave: false,
+				defaults: {
+					preferences: DEFAULT_PREFERENCES,
+					userThemes: [],
+				},
+			});
+
+			const preferences = (await store.get("preferences")) as ThemePreferences | null;
+			const userThemes = (await store.get("userThemes")) as Theme[] | null;
+
+			if (preferences) {
+				this.preferences = preferences;
+			}
+			if (userThemes) {
+				this.userThemes = userThemes;
+			}
+
+			this.isLoaded = true;
+		} catch (error) {
+			console.error("Failed to load theme preferences:", error);
+			this.isLoaded = true;
+		}
+	}
+
+	/**
+	 * Apply the active theme to the DOM
+	 */
+	applyActiveTheme(): void {
+		if (!this.isLoaded) return;
+
+		const theme = this.activeTheme;
+		applyTheme(theme);
+
+		// Cache for flash prevention
+		cacheThemeColors(theme.colors, theme.isDark);
+	}
+
+	/**
+	 * Set the theme for light mode
+	 */
+	setLightTheme(themeId: string): void {
+		const theme = this.lightThemes.find((t) => t.id === themeId);
+		if (!theme) return;
+
+		this.preferences = {
+			...this.preferences,
+			lightThemeId: themeId,
+		};
+
+		this.schedulePersist();
+	}
+
+	/**
+	 * Set the theme for dark mode
+	 */
+	setDarkTheme(themeId: string): void {
+		const theme = this.darkThemes.find((t) => t.id === themeId);
+		if (!theme) return;
+
+		this.preferences = {
+			...this.preferences,
+			darkThemeId: themeId,
+		};
+
+		this.schedulePersist();
+	}
+
+	/**
+	 * Add a new user theme
+	 */
+	addTheme(
+		theme: Omit<Theme, "id" | "isBuiltIn" | "createdAt" | "updatedAt">
+	): Theme {
+		const now = new Date().toISOString();
+		const newTheme: Theme = {
+			...theme,
+			id: crypto.randomUUID(),
+			isBuiltIn: false,
+			createdAt: now,
+			updatedAt: now,
+		};
+
+		this.userThemes = [...this.userThemes, newTheme];
+		this.schedulePersist();
+
+		return newTheme;
+	}
+
+	/**
+	 * Update an existing user theme
+	 */
+	updateTheme(id: string, updates: Partial<Omit<Theme, "id" | "isBuiltIn">>): void {
+		const index = this.userThemes.findIndex((t) => t.id === id);
+		if (index === -1) return;
+
+		const existing = this.userThemes[index];
+		const updated: Theme = {
+			...existing,
+			...updates,
+			updatedAt: new Date().toISOString(),
+		};
+
+		this.userThemes = [
+			...this.userThemes.slice(0, index),
+			updated,
+			...this.userThemes.slice(index + 1),
+		];
+
+		this.schedulePersist();
+	}
+
+	/**
+	 * Delete a user theme
+	 */
+	deleteTheme(id: string): void {
+		const theme = this.userThemes.find((t) => t.id === id);
+		if (!theme) return;
+
+		this.userThemes = this.userThemes.filter((t) => t.id !== id);
+
+		// If this theme was selected, reset to default
+		if (this.preferences.lightThemeId === id) {
+			this.preferences = {
+				...this.preferences,
+				lightThemeId: "default-light",
+			};
+		}
+		if (this.preferences.darkThemeId === id) {
+			this.preferences = {
+				...this.preferences,
+				darkThemeId: "default-dark",
+			};
+		}
+
+		this.schedulePersist();
+	}
+
+	/**
+	 * Duplicate a theme (creates editable copy)
+	 */
+	duplicateTheme(id: string): Theme | null {
+		const source = this.allThemes.find((t) => t.id === id);
+		if (!source) return null;
+
+		return this.addTheme({
+			name: `${source.name} (Copy)`,
+			description: source.description,
+			author: source.author,
+			isDark: source.isDark,
+			colors: { ...source.colors },
+		});
+	}
+
+	/**
+	 * Import a theme from JSON
+	 */
+	importTheme(json: string): Theme {
+		const parsed = JSON.parse(json) as ThemeExport;
+
+		// Validate required fields
+		if (!parsed.name || typeof parsed.name !== "string") {
+			throw new Error("Theme must have a name");
+		}
+		if (typeof parsed.isDark !== "boolean") {
+			throw new Error("Theme must specify isDark");
+		}
+		if (!validateThemeColors(parsed.colors)) {
+			throw new Error("Theme has invalid or missing color values");
+		}
+
+		return this.addTheme({
+			name: parsed.name,
+			description: parsed.description,
+			author: parsed.author,
+			isDark: parsed.isDark,
+			colors: parsed.colors,
+		});
+	}
+
+	/**
+	 * Export a theme to JSON
+	 */
+	exportTheme(id: string): string {
+		const theme = this.allThemes.find((t) => t.id === id);
+		if (!theme) {
+			throw new Error("Theme not found");
+		}
+
+		const exportData: ThemeExport = {
+			name: theme.name,
+			description: theme.description,
+			author: theme.author,
+			isDark: theme.isDark,
+			colors: theme.colors,
+		};
+
+		return JSON.stringify(exportData, null, 2);
+	}
+
+	/**
+	 * Get a theme by ID
+	 */
+	getTheme(id: string): Theme | undefined {
+		return this.allThemes.find((t) => t.id === id);
+	}
+
+	/**
+	 * Check if a theme is currently active
+	 */
+	isThemeActive(id: string): boolean {
+		return (
+			this.preferences.lightThemeId === id || this.preferences.darkThemeId === id
+		);
+	}
+
+	// Persistence
+
+	private schedulePersist(): void {
+		if (this.persistenceTimer) {
+			clearTimeout(this.persistenceTimer);
+		}
+		this.persistenceTimer = setTimeout(() => {
+			this.persist();
+			this.persistenceTimer = null;
+		}, this.PERSISTENCE_DEBOUNCE_MS);
+	}
+
+	private async persist(): Promise<void> {
+		try {
+			const store = await load(STORE_FILE, {
+				autoSave: true,
+				defaults: {
+					preferences: DEFAULT_PREFERENCES,
+					userThemes: [],
+				},
+			});
+
+			await store.set("preferences", this.preferences);
+			await store.set("userThemes", this.userThemes);
+			await store.save();
+		} catch (error) {
+			console.error("Failed to persist theme settings:", error);
+		}
+	}
+
+	/**
+	 * Flush pending persistence immediately
+	 */
+	flush(): void {
+		if (this.persistenceTimer) {
+			clearTimeout(this.persistenceTimer);
+			this.persistenceTimer = null;
+			this.persist();
+		}
+	}
+}
+
+export const themeStore = new ThemeStore();

--- a/src/lib/utils/theme-editor-window.ts
+++ b/src/lib/utils/theme-editor-window.ts
@@ -1,0 +1,71 @@
+import { WebviewWindow, getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
+import type { Theme } from "$lib/types/theme";
+
+let themeEditorWindow: WebviewWindow | null = null;
+
+/**
+ * Opens the theme editor in a separate window.
+ * If the window is already open, focuses it instead.
+ * @param theme - The theme to edit, or null to create a new theme
+ */
+export async function openThemeEditor(theme: Theme | null): Promise<void> {
+	try {
+		// Check if window already exists
+		const existing = await WebviewWindow.getByLabel("theme-editor");
+		if (existing) {
+			await existing.setFocus();
+			return;
+		}
+
+		// Build URL with query params
+		const url = theme ? `/windows/theme-editor?themeId=${encodeURIComponent(theme.id)}` : "/windows/theme-editor";
+
+		// Get the main window to set as parent
+		const mainWindow = getCurrentWebviewWindow();
+
+		// Create new window
+		themeEditorWindow = new WebviewWindow("theme-editor", {
+			url,
+			title: theme ? `Edit Theme: ${theme.name}` : "Create New Theme",
+			width: 800,
+			height: 600,
+			minWidth: 700,
+			minHeight: 500,
+			center: true,
+			resizable: true,
+			decorations: true,
+			alwaysOnTop: false,
+			parent: mainWindow,
+		});
+
+		// Handle window creation error
+		themeEditorWindow.once("tauri://error", (e) => {
+			console.error("Failed to create theme editor window:", e);
+			themeEditorWindow = null;
+		});
+
+		// Handle window close
+		themeEditorWindow.once("tauri://destroyed", () => {
+			themeEditorWindow = null;
+		});
+	} catch (error) {
+		console.error("Error opening theme editor:", error);
+	}
+}
+
+/**
+ * Closes the theme editor window if it's open.
+ */
+export async function closeThemeEditor(): Promise<void> {
+	if (themeEditorWindow) {
+		await themeEditorWindow.close();
+		themeEditorWindow = null;
+	}
+}
+
+/**
+ * Checks if the theme editor window is currently open.
+ */
+export function isThemeEditorOpen(): boolean {
+	return themeEditorWindow !== null;
+}

--- a/src/routes/windows/theme-editor/+layout@.svelte
+++ b/src/routes/windows/theme-editor/+layout@.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import "../../layout.css";
+	import { ModeWatcher } from "mode-watcher";
+	import { themeStore } from "$lib/stores/theme.svelte.js";
+	import { onMount } from "svelte";
+
+	let { children } = $props();
+
+	// Initialize theme store for this window
+	onMount(async () => {
+		await themeStore.initialize();
+	});
+
+	// Apply theme colors to this window too
+	$effect(() => {
+		if (themeStore.isLoaded) {
+			themeStore.applyActiveTheme();
+	}
+	});
+</script>
+
+<ModeWatcher />
+
+<div class="min-h-screen bg-background text-foreground">
+	{@render children()}
+</div>

--- a/src/routes/windows/theme-editor/+page.svelte
+++ b/src/routes/windows/theme-editor/+page.svelte
@@ -1,0 +1,312 @@
+<script lang="ts">
+	import { page } from "$app/state";
+	import { m } from "$lib/paraglide/messages.js";
+	import * as Tabs from "$lib/components/ui/tabs/index.js";
+	import { Button } from "$lib/components/ui/button";
+	import { Input } from "$lib/components/ui/input";
+	import { Label } from "$lib/components/ui/label";
+	import { Switch } from "$lib/components/ui/switch";
+	import { ScrollArea } from "$lib/components/ui/scroll-area";
+	import { themeStore } from "$lib/stores/theme.svelte.js";
+	import { BUILT_IN_THEMES } from "$lib/themes/presets";
+	import { getColorLabel } from "$lib/themes/color-utils";
+	import { applyThemeColors } from "$lib/themes/apply";
+	import { COLOR_GROUPS, type Theme, type ThemeColors } from "$lib/types/theme";
+	import ColorPicker from "$lib/components/color-picker.svelte";
+	import { emit } from "@tauri-apps/api/event";
+	import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
+	import { onMount } from "svelte";
+
+	// Get theme ID from URL params
+	const themeId = $derived(page.url.searchParams.get("themeId"));
+	const isEditing = $derived(themeId !== null);
+
+	// Form state
+	let themeName = $state("");
+	let isDark = $state(false);
+	let colors = $state<ThemeColors>({ ...BUILT_IN_THEMES[0].colors });
+
+	// Store original theme to restore on cancel
+	let originalColors: ThemeColors | null = null;
+	let initialized = $state(false);
+
+	// Initialize when store is loaded
+	$effect(() => {
+		if (themeStore.isLoaded && !initialized) {
+			// Store the current theme colors to restore on cancel
+			originalColors = { ...themeStore.activeTheme.colors };
+
+			if (themeId) {
+				// Editing existing theme
+				const editTheme = themeStore.getTheme(themeId);
+				if (editTheme) {
+					themeName = editTheme.name;
+					isDark = editTheme.isDark;
+					colors = { ...editTheme.colors };
+				}
+			} else {
+				// Creating new theme - start with current active theme colors
+				themeName = "";
+				isDark = themeStore.activeTheme.isDark;
+				colors = { ...themeStore.activeTheme.colors };
+			}
+			initialized = true;
+		}
+	});
+
+	// Apply colors in real-time and emit to main window
+	$effect(() => {
+		if (initialized) {
+			applyThemeColors(colors);
+			// Emit to main window for real-time preview
+			emit("theme-editor:color-update", { colors });
+		}
+	});
+
+	// Handle window close button (treat as cancel)
+	onMount(() => {
+		const currentWindow = getCurrentWebviewWindow();
+		const unlisten = currentWindow.onCloseRequested(async (event) => {
+			// Prevent default close behavior so we can emit cancel first
+			event.preventDefault();
+			// Emit cancel event
+			await emit("theme-editor:cancel", {});
+			// Now destroy the window
+			await currentWindow.destroy();
+		});
+
+		return () => {
+			unlisten.then((fn) => fn());
+		};
+	});
+
+	const dialogTitle = $derived(isEditing ? m.theme_editor_title_edit() : m.theme_editor_title_new());
+
+	function updateColor(key: keyof ThemeColors, value: string) {
+		colors = { ...colors, [key]: value };
+	}
+
+	async function handleSave() {
+		if (!themeName.trim()) {
+			// Show inline error
+			return;
+		}
+
+		// Emit save event to main window
+		await emit("theme-editor:save", {
+			themeId: themeId,
+			name: themeName.trim(),
+			isDark,
+			colors,
+		});
+
+		// Destroy the window (use destroy to skip onCloseRequested)
+		const currentWindow = getCurrentWebviewWindow();
+		await currentWindow.destroy();
+	}
+
+	async function handleCancel() {
+		// Restore original theme colors locally
+		if (originalColors) {
+			applyThemeColors(originalColors);
+		}
+		// Emit cancel event
+		await emit("theme-editor:cancel", {});
+		// Destroy the window (use destroy to skip onCloseRequested)
+		const currentWindow = getCurrentWebviewWindow();
+		await currentWindow.destroy();
+	}
+
+	// Get color group name for display
+	function getGroupName(groupName: string): string {
+		switch (groupName) {
+			case "Background":
+				return m.theme_editor_group_background();
+			case "Interactive":
+				return m.theme_editor_group_interactive();
+			case "Status":
+				return m.theme_editor_group_status();
+			case "Borders":
+				return m.theme_editor_group_borders();
+			case "Charts":
+				return m.theme_editor_group_charts();
+			case "Sidebar":
+				return m.theme_editor_group_sidebar();
+			default:
+				return groupName;
+		}
+	}
+</script>
+
+<div class="flex flex-col h-screen">
+	<!-- Header with drag region -->
+	<header class="h-12 flex items-center justify-between px-4 border-b bg-background" data-tauri-drag-region>
+		<h1 class="text-sm font-medium">{dialogTitle}</h1>
+		<div class="flex gap-2">
+			<Button variant="outline" size="sm" onclick={handleCancel}>
+				{m.theme_editor_cancel()}
+			</Button>
+			<Button size="sm" onclick={handleSave}>
+				{m.theme_editor_save()}
+			</Button>
+		</div>
+	</header>
+
+	<!-- Content -->
+	<div class="flex-1 min-h-0 p-4">
+		<div class="grid grid-cols-[1fr_220px] gap-6 h-full">
+			<!-- Left side: Form -->
+			<div class="flex flex-col gap-4 min-h-0">
+				<!-- Theme Name & Mode -->
+				<div class="grid grid-cols-2 gap-4">
+					<div class="space-y-2">
+						<Label for="theme-name">{m.theme_editor_name()}</Label>
+						<Input id="theme-name" bind:value={themeName} placeholder={m.theme_editor_name_placeholder()} />
+					</div>
+					<div class="space-y-2">
+						<Label>{m.theme_editor_mode()}</Label>
+						<div class="flex items-center gap-3 h-9">
+							<span class="text-sm text-muted-foreground">{m.theme_editor_mode_light()}</span>
+							<Switch bind:checked={isDark} />
+							<span class="text-sm text-muted-foreground">{m.theme_editor_mode_dark()}</span>
+						</div>
+					</div>
+				</div>
+
+				<!-- Color Groups -->
+				<div class="flex-1 min-h-0">
+					<Label class="mb-2 block">{m.theme_editor_colors()}</Label>
+					<ScrollArea class="h-[calc(100%-2rem)] border rounded-lg p-3">
+						<Tabs.Root value="Background" class="w-full">
+							<Tabs.List class="w-full justify-start flex-wrap h-auto gap-1 mb-4">
+								{#each COLOR_GROUPS as group (group.name)}
+									<Tabs.Trigger value={group.name} class="text-xs px-2 py-1">
+										{getGroupName(group.name)}
+									</Tabs.Trigger>
+								{/each}
+							</Tabs.List>
+
+							{#each COLOR_GROUPS as group (group.name)}
+								<Tabs.Content value={group.name} class="space-y-3">
+									{#each group.keys as key (key)}
+										<ColorPicker
+											value={colors[key as keyof ThemeColors]}
+											label={getColorLabel(key as keyof ThemeColors)}
+											onchange={(v) => updateColor(key as keyof ThemeColors, v)}
+										/>
+									{/each}
+								</Tabs.Content>
+							{/each}
+						</Tabs.Root>
+					</ScrollArea>
+				</div>
+			</div>
+
+			<!-- Right side: Preview -->
+			<div class="space-y-2">
+				<Label>{m.theme_editor_preview()}</Label>
+				<div
+					class="border rounded-lg p-4 h-[calc(100%-2rem)] overflow-y-auto"
+					style="
+						background-color: {colors.background};
+						color: {colors.foreground};
+					"
+				>
+					<div class="space-y-3">
+						<!-- Card preview -->
+						<div
+							class="rounded-lg border p-3"
+							style="
+								background-color: {colors.card};
+								color: {colors.cardForeground};
+								border-color: {colors.border};
+							"
+						>
+							<div class="text-sm font-medium mb-1">Card Title</div>
+							<div class="text-xs" style="color: {colors.mutedForeground}">Card description text</div>
+						</div>
+
+						<!-- Button previews -->
+						<div class="flex gap-2 flex-wrap">
+							<div
+								class="rounded px-2 py-1 text-xs"
+								style="
+									background-color: {colors.primary};
+									color: {colors.primaryForeground};
+								"
+							>
+								Primary
+							</div>
+							<div
+								class="rounded px-2 py-1 text-xs"
+								style="
+									background-color: {colors.secondary};
+									color: {colors.secondaryForeground};
+								"
+							>
+								Secondary
+							</div>
+						</div>
+
+						<!-- Accent preview -->
+						<div
+							class="rounded px-2 py-1 text-xs inline-block"
+							style="
+								background-color: {colors.accent};
+								color: {colors.accentForeground};
+							"
+						>
+							Accent
+						</div>
+
+						<!-- Destructive preview -->
+						<div class="rounded px-2 py-1 text-xs inline-block" style="background-color: {colors.destructive}; color: white;">
+							Destructive
+						</div>
+
+						<!-- Input preview -->
+						<div
+							class="rounded border px-2 py-1 text-xs"
+							style="
+								background-color: {colors.background};
+								border-color: {colors.input};
+								color: {colors.foreground};
+							"
+						>
+							Input field
+						</div>
+
+						<!-- Sidebar preview -->
+						<div
+							class="rounded-lg p-2 text-xs"
+							style="
+								background-color: {colors.sidebar};
+								color: {colors.sidebarForeground};
+							"
+						>
+							<div class="mb-1">Sidebar</div>
+							<div
+								class="rounded px-1 py-0.5"
+								style="
+									background-color: {colors.sidebarAccent};
+									color: {colors.sidebarAccentForeground};
+								"
+							>
+								Active item
+							</div>
+						</div>
+
+						<!-- Chart colors preview -->
+						<div class="flex gap-1">
+							<div class="w-4 h-4 rounded" style="background-color: {colors.chart1}"></div>
+							<div class="w-4 h-4 rounded" style="background-color: {colors.chart2}"></div>
+							<div class="w-4 h-4 rounded" style="background-color: {colors.chart3}"></div>
+							<div class="w-4 h-4 rounded" style="background-color: {colors.chart4}"></div>
+							<div class="w-4 h-4 rounded" style="background-color: {colors.chart5}"></div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## Summary
- Add comprehensive theme editor allowing users to create, edit, and manage custom color themes
- Implement real-time theme preview via separate Tauri webview window
- Add theme import/export functionality (JSON format)
- Add theme selection in settings for light/dark mode preferences
- Include UI components: alert-dialog, switch, color-picker, theme-preview

## Test plan
- [ ] Open Settings → Appearance → Themes section
- [ ] Create a new custom theme using the theme editor
- [ ] Verify real-time color preview updates in the main window
- [ ] Test theme duplication, export, and import functionality
- [ ] Verify theme persistence across app restarts
- [ ] Test light/dark theme selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)