### PR TITLE
Add DBeaver connection import functionality

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -398,5 +398,15 @@
 	"migration_description": "سنساعدك في التعرف على الأماكن",
 	"migration_skip": "تخطي، أنا جديد في أدوات قواعد البيانات",
 	"migration_ui_mapping": "إليك الاختلاف",
-	"migration_change": "تغيير التحديد"
+	"migration_change": "تغيير التحديد",
+	"dbeaver_import_title": "استيراد اتصالات DBeaver",
+	"dbeaver_import_description": "وجدنا اتصالات DBeaver على نظامك. هل تريد استيرادها إلى Seaquel؟",
+	"dbeaver_import_found": "تم العثور على {count} اتصال(ات)",
+	"dbeaver_import_select_all": "تحديد الكل",
+	"dbeaver_import_deselect_all": "إلغاء تحديد الكل",
+	"dbeaver_import_duplicate": "موجود بالفعل",
+	"dbeaver_import_password_note": "لأسباب أمنية، لا يتم استيراد كلمات المرور. ستحتاج إلى إدخالها عند الاتصال.",
+	"dbeaver_import_skip": "تخطي",
+	"dbeaver_import_button": "استيراد {count} اتصال(ات)",
+	"dbeaver_import_success": "تم استيراد {count} اتصال(ات) بنجاح"
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -398,5 +398,15 @@
 	"migration_description": "Wir helfen Ihnen, sich zurechtzufinden",
 	"migration_skip": "Überspringen, ich bin neu bei Datenbank-Tools",
 	"migration_ui_mapping": "Hier ist der Unterschied",
-	"migration_change": "Auswahl ändern"
+	"migration_change": "Auswahl ändern",
+	"dbeaver_import_title": "DBeaver-Verbindungen importieren",
+	"dbeaver_import_description": "Wir haben DBeaver-Verbindungen auf Ihrem System gefunden. Möchten Sie diese in Seaquel importieren?",
+	"dbeaver_import_found": "{count} Verbindung(en) gefunden",
+	"dbeaver_import_select_all": "Alle auswählen",
+	"dbeaver_import_deselect_all": "Alle abwählen",
+	"dbeaver_import_duplicate": "Existiert bereits",
+	"dbeaver_import_password_note": "Aus Sicherheitsgründen werden Passwörter nicht importiert. Sie müssen diese beim Verbinden eingeben.",
+	"dbeaver_import_skip": "Überspringen",
+	"dbeaver_import_button": "{count} Verbindung(en) importieren",
+	"dbeaver_import_success": "{count} Verbindung(en) erfolgreich importiert"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -398,5 +398,15 @@
 	"migration_description": "We'll help you find your way around",
 	"migration_skip": "Skip, I'm new to database tools",
 	"migration_ui_mapping": "Here's what's different",
-	"migration_change": "Change selection"
+	"migration_change": "Change selection",
+	"dbeaver_import_title": "Import DBeaver Connections",
+	"dbeaver_import_description": "We found DBeaver connections on your system. Would you like to import them into Seaquel?",
+	"dbeaver_import_found": "Found {count} connection(s)",
+	"dbeaver_import_select_all": "Select all",
+	"dbeaver_import_deselect_all": "Deselect all",
+	"dbeaver_import_duplicate": "Already exists",
+	"dbeaver_import_password_note": "For security, passwords are not imported. You'll need to enter them when connecting.",
+	"dbeaver_import_skip": "Skip",
+	"dbeaver_import_button": "Import {count} connection(s)",
+	"dbeaver_import_success": "Successfully imported {count} connection(s)"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -398,5 +398,15 @@
 	"migration_description": "Te ayudaremos a orientarte",
 	"migration_skip": "Omitir, soy nuevo en herramientas de bases de datos",
 	"migration_ui_mapping": "Aquí está la diferencia",
-	"migration_change": "Cambiar selección"
+	"migration_change": "Cambiar selección",
+	"dbeaver_import_title": "Importar conexiones de DBeaver",
+	"dbeaver_import_description": "Encontramos conexiones de DBeaver en tu sistema. ¿Te gustaría importarlas a Seaquel?",
+	"dbeaver_import_found": "Se encontraron {count} conexión(es)",
+	"dbeaver_import_select_all": "Seleccionar todo",
+	"dbeaver_import_deselect_all": "Deseleccionar todo",
+	"dbeaver_import_duplicate": "Ya existe",
+	"dbeaver_import_password_note": "Por seguridad, las contraseñas no se importan. Deberás ingresarlas al conectar.",
+	"dbeaver_import_skip": "Omitir",
+	"dbeaver_import_button": "Importar {count} conexión(es)",
+	"dbeaver_import_success": "Se importaron {count} conexión(es) exitosamente"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -398,5 +398,15 @@
 	"migration_description": "Nous vous aiderons à vous repérer",
 	"migration_skip": "Ignorer, je suis nouveau dans les outils de base de données",
 	"migration_ui_mapping": "Voici les différences",
-	"migration_change": "Modifier la sélection"
+	"migration_change": "Modifier la sélection",
+	"dbeaver_import_title": "Importer les connexions DBeaver",
+	"dbeaver_import_description": "Nous avons trouvé des connexions DBeaver sur votre système. Souhaitez-vous les importer dans Seaquel ?",
+	"dbeaver_import_found": "{count} connexion(s) trouvée(s)",
+	"dbeaver_import_select_all": "Tout sélectionner",
+	"dbeaver_import_deselect_all": "Tout désélectionner",
+	"dbeaver_import_duplicate": "Existe déjà",
+	"dbeaver_import_password_note": "Pour des raisons de sécurité, les mots de passe ne sont pas importés. Vous devrez les saisir lors de la connexion.",
+	"dbeaver_import_skip": "Ignorer",
+	"dbeaver_import_button": "Importer {count} connexion(s)",
+	"dbeaver_import_success": "{count} connexion(s) importée(s) avec succès"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -398,5 +398,15 @@
 	"migration_description": "둘러보실 수 있도록 도와드리겠습니다",
 	"migration_skip": "건너뛰기, 데이터베이스 도구는 처음입니다",
 	"migration_ui_mapping": "여기가 다른 점입니다",
-	"migration_change": "선택 변경"
+	"migration_change": "선택 변경",
+	"dbeaver_import_title": "DBeaver 연결 가져오기",
+	"dbeaver_import_description": "시스템에서 DBeaver 연결을 발견했습니다. Seaquel로 가져오시겠습니까?",
+	"dbeaver_import_found": "{count}개 연결 발견",
+	"dbeaver_import_select_all": "전체 선택",
+	"dbeaver_import_deselect_all": "전체 해제",
+	"dbeaver_import_duplicate": "이미 존재함",
+	"dbeaver_import_password_note": "보안을 위해 비밀번호는 가져오지 않습니다. 연결 시 입력해야 합니다.",
+	"dbeaver_import_skip": "건너뛰기",
+	"dbeaver_import_button": "{count}개 연결 가져오기",
+	"dbeaver_import_success": "{count}개 연결을 성공적으로 가져왔습니다"
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1073,11 +1073,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1088,7 +1109,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -4309,6 +4330,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4806,6 +4838,7 @@ dependencies = [
  "async-native-tls 0.5.0",
  "async-trait",
  "base64 0.22.1",
+ "dirs 5.0.1",
  "image",
  "russh",
  "russh-keys",
@@ -5676,7 +5709,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -5726,7 +5759,7 @@ checksum = "17fcb8819fd16463512a12f531d44826ce566f486d7ccd211c9c8cebdaec4e08"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -5923,7 +5956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27cbc31740f4d507712550694749572ec0e43bdd66992db7599b89fbfd6b167b"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -6460,7 +6493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -7645,7 +7678,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dpi",
  "dunce",
  "gdkx11",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ tauri-plugin-os = "2"
 tauri-plugin-clipboard-manager = "2.3.2"
 arboard = "3.6.1"
 image = "0.25.9"
+dirs = "5"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src/lib/components/dbeaver-import-dialog.svelte
+++ b/src/lib/components/dbeaver-import-dialog.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	import * as Dialog from "$lib/components/ui/dialog/index.js";
+	import { Button } from "$lib/components/ui/button";
+	import { Checkbox } from "$lib/components/ui/checkbox";
+	import { dbeaverImportStore } from "$lib/stores/dbeaver-import.svelte.js";
+	import { useDatabase } from "$lib/hooks/database.svelte.js";
+	import { toast } from "svelte-sonner";
+	import { m } from "$lib/paraglide/messages.js";
+	import DatabaseIcon from "@lucide/svelte/icons/database";
+	import AlertTriangleIcon from "@lucide/svelte/icons/alert-triangle";
+	import type { DatabaseConnection } from "$lib/types";
+
+	const db = useDatabase();
+
+	const selectedCount = $derived(
+		dbeaverImportStore.connections.filter((c) => c.selected).length
+	);
+
+	const hasSelections = $derived(selectedCount > 0);
+
+	async function handleImport() {
+		const selected = dbeaverImportStore.getSelectedConnections();
+		let importedCount = 0;
+
+		for (const conn of selected) {
+			try {
+				// Generate the connection ID that Seaquel would use
+				const connectionId =
+					conn.type === "sqlite"
+						? `conn-sqlite-${conn.databaseName}`
+						: `conn-${conn.host}-${conn.port}`;
+
+				// Check if already exists
+				if (db.state.connections.find((c) => c.id === connectionId)) {
+					continue;
+				}
+
+				// Create connection object (without connecting - password is empty)
+				const newConnection: DatabaseConnection = {
+					id: connectionId,
+					name: conn.name,
+					type: conn.type,
+					host: conn.host,
+					port: conn.port,
+					databaseName: conn.databaseName,
+					username: conn.username,
+					password: "", // User must enter this when connecting
+				};
+
+				// Add to state
+				db.state.connections.push(newConnection);
+
+				// Persist
+				await db.persistence.persistConnection(newConnection);
+
+				importedCount++;
+			} catch (error) {
+				console.error(`Failed to import connection ${conn.name}:`, error);
+			}
+		}
+
+		if (importedCount > 0) {
+			toast.success(m.dbeaver_import_success({ count: importedCount }));
+		}
+
+		await dbeaverImportStore.completeImport();
+	}
+
+	async function handleDismiss() {
+		await dbeaverImportStore.dismiss();
+	}
+</script>
+
+<Dialog.Root bind:open={dbeaverImportStore.isOpen}>
+	<Dialog.Content class="max-w-lg">
+		<Dialog.Header>
+			<Dialog.Title class="flex items-center gap-2">
+				<DatabaseIcon class="size-5" />
+				{m.dbeaver_import_title()}
+			</Dialog.Title>
+			<Dialog.Description>
+				{m.dbeaver_import_description()}
+			</Dialog.Description>
+		</Dialog.Header>
+
+		<div class="space-y-4 py-4">
+			<!-- Selection controls -->
+			<div class="flex items-center justify-between text-sm">
+				<span class="text-muted-foreground">
+					{m.dbeaver_import_found({ count: dbeaverImportStore.connections.length })}
+				</span>
+				<div class="flex gap-2">
+					<Button
+						variant="ghost"
+						size="sm"
+						onclick={() => dbeaverImportStore.selectAll()}
+					>
+						{m.dbeaver_import_select_all()}
+					</Button>
+					<Button
+						variant="ghost"
+						size="sm"
+						onclick={() => dbeaverImportStore.deselectAll()}
+					>
+						{m.dbeaver_import_deselect_all()}
+					</Button>
+				</div>
+			</div>
+
+			<!-- Connection list -->
+			<div class="max-h-64 overflow-y-auto space-y-2 border rounded-lg p-2">
+				{#each dbeaverImportStore.connections as conn, index}
+					<label
+						class="flex items-center gap-3 p-2 rounded-md hover:bg-muted/50 cursor-pointer transition-colors"
+						class:opacity-50={conn.isDuplicate}
+					>
+						<Checkbox
+							checked={conn.selected}
+							disabled={conn.isDuplicate}
+							onCheckedChange={() => dbeaverImportStore.toggleConnection(index)}
+						/>
+						<div class="flex-1 min-w-0">
+							<div class="flex items-center gap-2">
+								<span class="font-medium truncate">{conn.name}</span>
+								<span class="text-xs text-muted-foreground uppercase"
+									>{conn.type}</span
+								>
+							</div>
+							<span class="text-xs text-muted-foreground truncate block">
+								{conn.username}@{conn.host}:{conn.port}/{conn.databaseName}
+							</span>
+						</div>
+						{#if conn.isDuplicate}
+							<span class="text-xs text-amber-500 flex items-center gap-1">
+								<AlertTriangleIcon class="size-3" />
+								{m.dbeaver_import_duplicate()}
+							</span>
+						{/if}
+					</label>
+				{/each}
+			</div>
+
+			<!-- Password note -->
+			<p class="text-xs text-muted-foreground">
+				{m.dbeaver_import_password_note()}
+			</p>
+		</div>
+
+		<Dialog.Footer>
+			<Button variant="ghost" onclick={handleDismiss}>
+				{m.dbeaver_import_skip()}
+			</Button>
+			<Button onclick={handleImport} disabled={!hasSelections}>
+				{m.dbeaver_import_button({ count: selectedCount })}
+			</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/empty-states/connections-grid.svelte
+++ b/src/lib/components/empty-states/connections-grid.svelte
@@ -3,6 +3,7 @@
 	import { useDatabase } from "$lib/hooks/database.svelte.js";
 	import { connectionDialogStore } from "$lib/stores/connection-dialog.svelte.js";
 	import ConnectionCard from "./connection-card.svelte";
+	import MigrationTrackSelector from "$lib/components/onboarding/migration-track-selector.svelte";
 	import { m } from "$lib/paraglide/messages.js";
 
 	const db = useDatabase();
@@ -40,6 +41,10 @@
 					<ConnectionCard {connection} />
 				</div>
 			{/each}
+		</div>
+
+		<div class="pt-4 border-t">
+			<MigrationTrackSelector />
 		</div>
 	</div>
 </div>

--- a/src/lib/components/onboarding/migration-track-selector.svelte
+++ b/src/lib/components/onboarding/migration-track-selector.svelte
@@ -2,6 +2,8 @@
 	import { Button } from "$lib/components/ui/button";
 	import { m } from "$lib/paraglide/messages.js";
 	import { onboardingStore, type UserBackground } from "$lib/stores/onboarding.svelte.js";
+	import { dbeaverImportStore } from "$lib/stores/dbeaver-import.svelte.js";
+	import { useDatabase } from "$lib/hooks/database.svelte.js";
 	import { migrationTracks, getMigrationTrack } from "$lib/config/migration-tracks.js";
 	import DatabaseIcon from "@lucide/svelte/icons/database";
 	import CheckIcon from "@lucide/svelte/icons/check";
@@ -13,14 +15,22 @@
 
 	let { onSelect }: Props = $props();
 
+	const db = useDatabase();
+
 	let selectedBackground = $state<UserBackground>(onboardingStore.userBackground);
 	let showConfirmation = $state(selectedBackground !== "none");
 
-	const handleSelect = (background: UserBackground) => {
+	const handleSelect = async (background: UserBackground) => {
 		selectedBackground = background;
 		onboardingStore.setBackground(background);
 		showConfirmation = background !== "none";
 		onSelect?.(background);
+
+		// Show DBeaver import dialog when user clicks DBeaver card
+		if (background === "dbeaver") {
+			const existingIds = db.state.connections.map((c) => c.id);
+			await dbeaverImportStore.checkAndShowDialog(existingIds);
+		}
 	};
 
 	const handleChangeSelection = () => {

--- a/src/lib/services/dbeaver-import.ts
+++ b/src/lib/services/dbeaver-import.ts
@@ -1,0 +1,114 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { DatabaseType } from "$lib/types";
+import type {
+	DbeaverDataSources,
+	DbeaverConnection,
+	ImportableConnection,
+} from "$lib/types/dbeaver";
+
+/**
+ * Maps DBeaver provider names to Seaquel database types
+ */
+const PROVIDER_MAP: Record<string, DatabaseType> = {
+	postgresql: "postgres",
+	postgres: "postgres",
+	mysql: "mysql",
+	mariadb: "mariadb",
+	sqlite: "sqlite",
+	mongodb: "mongodb",
+	mssql: "mssql",
+	sqlserver: "mssql",
+};
+
+/**
+ * Default ports for each database type
+ */
+const DEFAULT_PORTS: Record<DatabaseType, number> = {
+	postgres: 5432,
+	mysql: 3306,
+	mariadb: 3306,
+	sqlite: 0,
+	mongodb: 27017,
+	mssql: 1433,
+};
+
+/**
+ * Reads and parses DBeaver's data-sources.json using a Rust command
+ * Returns an array of connections or empty array if not found
+ */
+export async function parseDbeaverConnections(): Promise<DbeaverConnection[]> {
+	try {
+		const content = await invoke<string | null>("read_dbeaver_config");
+
+		if (!content) {
+			return [];
+		}
+
+		const data = JSON.parse(content) as DbeaverDataSources;
+
+		if (!data.connections) {
+			return [];
+		}
+
+		return Object.entries(data.connections).map(([id, conn]) => ({
+			...conn,
+			id,
+		}));
+	} catch (error) {
+		console.error("Failed to read DBeaver config:", error);
+		return [];
+	}
+}
+
+/**
+ * Maps a DBeaver connection to an importable connection format
+ * Returns null if the database type is not supported
+ */
+export function mapToImportable(
+	dbeaverConn: DbeaverConnection,
+	existingConnectionIds: string[]
+): ImportableConnection | null {
+	const type = PROVIDER_MAP[dbeaverConn.provider?.toLowerCase()];
+	if (!type) {
+		return null; // Unsupported database type
+	}
+
+	const config = dbeaverConn.configuration || {};
+	const host = config.host || "localhost";
+	const port = parseInt(config.port || String(DEFAULT_PORTS[type]), 10);
+	const databaseName = config.database || "";
+	const username = config.user || "";
+
+	// Generate the connection ID that Seaquel would use
+	const expectedId =
+		type === "sqlite"
+			? `conn-sqlite-${databaseName}`
+			: `conn-${host}-${port}`;
+
+	const isDuplicate = existingConnectionIds.includes(expectedId);
+
+	return {
+		original: dbeaverConn,
+		name: dbeaverConn.name,
+		type,
+		host,
+		port,
+		databaseName,
+		username,
+		isDuplicate,
+		selected: !isDuplicate, // Pre-select non-duplicates
+	};
+}
+
+/**
+ * Discovers and parses all DBeaver connections, filtering for supported types
+ */
+export async function discoverDbeaverConnections(
+	existingConnectionIds: string[]
+): Promise<ImportableConnection[]> {
+	const dbeaverConnections = await parseDbeaverConnections();
+
+	return dbeaverConnections
+		.map((conn) => mapToImportable(conn, existingConnectionIds))
+		.filter((conn): conn is ImportableConnection => conn !== null);
+}

--- a/src/lib/stores/dbeaver-import.svelte.ts
+++ b/src/lib/stores/dbeaver-import.svelte.ts
@@ -1,0 +1,150 @@
+import { load } from "@tauri-apps/plugin-store";
+import type { ImportableConnection } from "$lib/types/dbeaver";
+import { discoverDbeaverConnections } from "$lib/services/dbeaver-import";
+
+interface PersistedDbeaverImportState {
+	hasOfferedImport: boolean;
+	lastCheckTimestamp?: string;
+}
+
+const STORE_FILE = "dbeaver_import_state.json";
+
+class DbeaverImportStore {
+	// Dialog state
+	isOpen = $state(false);
+	isLoading = $state(false);
+
+	// Discovered connections
+	connections = $state<ImportableConnection[]>([]);
+
+	// Persistence tracking
+	hasOfferedImport = $state(false);
+	private initialized = false;
+
+	/**
+	 * Initialize the store - loads persisted state
+	 */
+	async initialize(): Promise<void> {
+		if (this.initialized) return;
+		this.initialized = true;
+
+		// Load persisted state
+		try {
+			const store = await load(STORE_FILE, {
+				autoSave: false,
+				defaults: { state: null },
+			});
+			const persisted = (await store.get("state")) as PersistedDbeaverImportState | null;
+
+			if (persisted) {
+				this.hasOfferedImport = persisted.hasOfferedImport;
+			}
+		} catch (error) {
+			console.error("Failed to load DBeaver import state:", error);
+		}
+	}
+
+	/**
+	 * Check for DBeaver connections and open dialog if found
+	 * Called when user clicks on DBeaver card
+	 */
+	async checkAndShowDialog(existingConnectionIds: string[]): Promise<void> {
+		// Skip if already offered import
+		if (this.hasOfferedImport) return;
+
+		this.isLoading = true;
+
+		try {
+			const importable = await discoverDbeaverConnections(existingConnectionIds);
+
+			if (importable.length > 0) {
+				this.connections = importable;
+				this.isOpen = true;
+			}
+		} catch (error) {
+			console.error("Failed to check DBeaver connections:", error);
+		} finally {
+			this.isLoading = false;
+		}
+	}
+
+	/**
+	 * Toggle selection state for a connection
+	 */
+	toggleConnection(index: number): void {
+		if (this.connections[index] && !this.connections[index].isDuplicate) {
+			this.connections[index].selected = !this.connections[index].selected;
+			// Trigger reactivity
+			this.connections = [...this.connections];
+		}
+	}
+
+	/**
+	 * Select all non-duplicate connections
+	 */
+	selectAll(): void {
+		this.connections = this.connections.map((c) => ({
+			...c,
+			selected: !c.isDuplicate,
+		}));
+	}
+
+	/**
+	 * Deselect all connections
+	 */
+	deselectAll(): void {
+		this.connections = this.connections.map((c) => ({
+			...c,
+			selected: false,
+		}));
+	}
+
+	/**
+	 * Get all selected connections
+	 */
+	getSelectedConnections(): ImportableConnection[] {
+		return this.connections.filter((c) => c.selected);
+	}
+
+	/**
+	 * Dismiss the dialog without importing
+	 */
+	async dismiss(): Promise<void> {
+		this.isOpen = false;
+		this.hasOfferedImport = true;
+		await this.persist();
+	}
+
+	/**
+	 * Complete the import and close dialog
+	 */
+	async completeImport(): Promise<void> {
+		this.isOpen = false;
+		this.hasOfferedImport = true;
+		await this.persist();
+	}
+
+	/**
+	 * Persist state to store
+	 */
+	private async persist(): Promise<void> {
+		try {
+			const store = await load(STORE_FILE, {
+				autoSave: true,
+				defaults: { state: null },
+			});
+
+			const state: PersistedDbeaverImportState = {
+				hasOfferedImport: this.hasOfferedImport,
+				lastCheckTimestamp: new Date().toISOString(),
+			};
+
+			await store.set("state", state);
+			await store.save();
+		} catch (error) {
+			console.error("Failed to persist DBeaver import state:", error);
+		}
+	}
+}
+
+export const dbeaverImportStore = new DbeaverImportStore();

--- a/src/lib/types/dbeaver.ts
+++ b/src/lib/types/dbeaver.ts
@@ -1,0 +1,46 @@
+import type { DatabaseType } from "$lib/types";
+
+/**
+ * DBeaver connection configuration as stored in data-sources.json
+ */
+export interface DbeaverConnectionConfig {
+	host?: string;
+	port?: string;
+	database?: string;
+	user?: string;
+	url?: string;
+}
+
+/**
+ * DBeaver connection entry from data-sources.json
+ */
+export interface DbeaverConnection {
+	id: string;
+	provider: string;
+	driver: string;
+	name: string;
+	configuration: DbeaverConnectionConfig;
+}
+
+/**
+ * Root structure of DBeaver's data-sources.json file
+ */
+export interface DbeaverDataSources {
+	folders?: Record<string, unknown>;
+	connections: Record<string, Omit<DbeaverConnection, "id">>;
+}
+
+/**
+ * A DBeaver connection that has been processed and is ready for import
+ */
+export interface ImportableConnection {
+	original: DbeaverConnection;
+	name: string;
+	type: DatabaseType;
+	host: string;
+	port: number;
+	databaseName: string;
+	username: string;
+	isDuplicate: boolean;
+	selected: boolean;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,12 +14,15 @@
 	import { settingsDialogStore } from "$lib/stores/settings-dialog.svelte.js";
 	import { themeStore } from "$lib/stores/theme.svelte.js";
 	import { applyThemeColors } from "$lib/themes/apply";
+	import DbeaverImportDialog from "$lib/components/dbeaver-import-dialog.svelte";
 	import type { ThemeColors } from "$lib/types/theme";
 	import { listen } from "@tauri-apps/api/event";
 	import { invoke } from "@tauri-apps/api/core";
 	import { toast } from "svelte-sonner";
 	import { m } from "$lib/paraglide/messages.js";
 	import { onMount } from "svelte";
+	import { onboardingStore } from "$lib/stores/onboarding.svelte.js";
+	import { dbeaverImportStore } from "$lib/stores/dbeaver-import.svelte.js";
 
 	setDatabase();
 
@@ -30,9 +33,11 @@
 	// Check if we're in the theme editor window (no app shell needed)
 	const isThemeEditor = $derived(page.url.pathname.startsWith("/windows/theme-editor"));
 
-	// Initialize theme store on mount
+	// Initialize stores on mount
 	onMount(async () => {
 		await themeStore.initialize();
+		await onboardingStore.initialize();
+		await dbeaverImportStore.initialize();
 	});
 
 	// Apply active theme whenever it changes
@@ -135,6 +140,7 @@
 	<KeyboardShortcutsDialog />
 	<CommandPalette />
 	<SettingsDialog />
+	<DbeaverImportDialog />
 
 	<Sidebar.Provider
 		class="[--header-height:calc(--spacing(8))] flex-col h-svh overflow-hidden"


### PR DESCRIPTION
## Summary
- Add `read_dbeaver_config` Rust command to read DBeaver's `data-sources.json` configuration file
- Create DBeaver import dialog component with connection selection and duplicate detection
- Integrate import trigger in onboarding migration track selector
- Support importing connections for PostgreSQL, MySQL, MariaDB, SQLite, MongoDB, and MSSQL
- Passwords are not imported for security reasons - users must enter them when connecting

## Test plan
- [ ] Test DBeaver detection when user selects "DBeaver" in migration track
- [ ] Test import dialog displays found connections correctly
- [ ] Test duplicate detection marks existing connections appropriately
- [ ] Test importing selected connections creates valid connection entries
- [ ] Verify imported connections can be used to connect (after entering password)

🤖 Generated with [Claude Code](https://claude.com/claude-code)