### PR TITLE
Add copy button to error messages for easier debugging

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -232,6 +232,7 @@
 	"query_cell_copied": "Cell value copied",
 	"query_row_copied": "Row copied as JSON",
 	"query_column_copied": "Column values copied",
+	"query_error_copied": "Error copied to clipboard",
 	"query_copy_cell": "Copy Cell Value",
 	"query_copy_row": "Copy Row as JSON",
 	"query_copy_column": "Copy Column Values",

--- a/src/lib/components/connection-wizard/wizard-step-credentials.svelte
+++ b/src/lib/components/connection-wizard/wizard-step-credentials.svelte
@@ -9,6 +9,8 @@
 	import UserIcon from "@lucide/svelte/icons/user";
 	import KeyIcon from "@lucide/svelte/icons/key";
 	import FolderIcon from "@lucide/svelte/icons/folder";
+	import CopyIcon from "@lucide/svelte/icons/copy";
+	import { toast } from "svelte-sonner";
 
 	interface Props {
 		formData: WizardFormData;
@@ -148,9 +150,24 @@
 
 		{#if error}
 			<div
-				class="p-3 rounded-lg border border-destructive/50 bg-destructive/10 text-destructive text-sm"
+				class="flex items-start gap-2 p-3 rounded-lg border border-destructive/50 bg-destructive/10 text-destructive text-sm"
 			>
-				{error}
+				<span class="flex-1">{error}</span>
+				<Button
+					variant="ghost"
+					size="icon"
+					class="shrink-0 size-6 text-destructive/70 hover:text-destructive hover:bg-destructive/20"
+					onclick={async () => {
+						try {
+							await navigator.clipboard.writeText(error ?? '');
+							toast.success(m.query_error_copied());
+						} catch {
+							toast.error(m.query_copy_failed());
+						}
+					}}
+				>
+					<CopyIcon class="size-3.5" />
+				</Button>
 			</div>
 		{/if}
 	</div>

--- a/src/lib/components/connection-wizard/wizard-step-string-paste.svelte
+++ b/src/lib/components/connection-wizard/wizard-step-string-paste.svelte
@@ -6,6 +6,8 @@
 	import { m } from "$lib/paraglide/messages.js";
 	import type { WizardFormData, DatabaseTypeConfig } from "$lib/stores/connection-wizard.svelte.js";
 	import CheckCircleIcon from "@lucide/svelte/icons/check-circle";
+	import CopyIcon from "@lucide/svelte/icons/copy";
+	import { toast } from "svelte-sonner";
 
 	interface Props {
 		formData: WizardFormData;
@@ -113,8 +115,23 @@
 		{/if}
 
 		{#if error}
-			<div class="p-3 rounded-lg border border-destructive/50 bg-destructive/10 text-destructive text-sm">
-				{error}
+			<div class="flex items-start gap-2 p-3 rounded-lg border border-destructive/50 bg-destructive/10 text-destructive text-sm">
+				<span class="flex-1">{error}</span>
+				<Button
+					variant="ghost"
+					size="icon"
+					class="shrink-0 size-6 text-destructive/70 hover:text-destructive hover:bg-destructive/20"
+					onclick={async () => {
+						try {
+							await navigator.clipboard.writeText(error ?? '');
+							toast.success(m.query_error_copied());
+						} catch {
+							toast.error(m.query_copy_failed());
+						}
+					}}
+				>
+					<CopyIcon class="size-3.5" />
+				</Button>
 			</div>
 		{/if}
 	</div>

--- a/src/lib/components/query-editor.svelte
+++ b/src/lib/components/query-editor.svelte
@@ -503,10 +503,27 @@
                             <div class="flex-1 p-4 bg-destructive/10 overflow-auto">
                                 <div class="flex items-start gap-3">
                                     <XCircleIcon class="size-5 text-destructive shrink-0 mt-0.5" />
-                                    <div class="space-y-3">
-                                        <div>
-                                            <h4 class="font-semibold text-destructive">{m.query_statement_failed({ n: activeResultIndex + 1 })}</h4>
-                                            <pre class="mt-2 text-sm whitespace-pre-wrap text-destructive/90 font-mono">{activeResult.error}</pre>
+                                    <div class="flex-1 space-y-3">
+                                        <div class="flex items-start justify-between gap-2">
+                                            <div>
+                                                <h4 class="font-semibold text-destructive">{m.query_statement_failed({ n: activeResultIndex + 1 })}</h4>
+                                                <pre class="mt-2 text-sm whitespace-pre-wrap text-destructive/90 font-mono">{activeResult.error}</pre>
+                                            </div>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                class="shrink-0 size-8 text-destructive/70 hover:text-destructive hover:bg-destructive/10"
+                                                onclick={async () => {
+                                                    try {
+                                                        await navigator.clipboard.writeText(activeResult.error ?? '');
+                                                        toast.success(m.query_error_copied());
+                                                    } catch {
+                                                        toast.error(m.query_copy_failed());
+                                                    }
+                                                }}
+                                            >
+                                                <CopyIcon class="size-4" />
+                                            </Button>
                                         </div>
                                         <details class="text-sm">
                                             <summary class="cursor-pointer text-muted-foreground hover:text-foreground">{m.query_show_sql()}</summary>


### PR DESCRIPTION
## Summary
- Add copy-to-clipboard button for connection errors in connection dialog
- Add copy button for errors in connection wizard steps (credentials, string paste)
- Add copy button for query execution errors in query editor
- Improve error object handling to extract meaningful messages from Tauri errors

## Test plan
- [ ] Test copying connection error in connection dialog
- [ ] Test copying error in connection wizard credential step
- [ ] Test copying error in connection wizard string paste step
- [ ] Test copying query execution error in query editor
- [ ] Verify toast notification shows "Error copied to clipboard"

🤖 Generated with [Claude Code](https://claude.com/claude-code)