### PR TITLE
Fix reconnect dialog button visibility

### DIFF
--- a/src/lib/components/connection-wizard/connection-wizard.svelte
+++ b/src/lib/components/connection-wizard/connection-wizard.svelte
@@ -121,21 +121,27 @@
 		return wizard.parseConnectionString(connStr);
 	};
 
+	const isReconnecting = $derived(wizard.reconnectingConnectionId !== null);
+
 	// Determine if we should show navigation buttons
-	const showBack = $derived(wizard.currentStep !== "string-choice");
+	const showBack = $derived(
+		wizard.currentStep !== "string-choice" &&
+			(!isReconnecting || wizard.currentStep === "advanced"),
+	);
 	const showNext = $derived(
 		wizard.currentStep !== "string-choice" &&
 			wizard.currentStep !== "credentials" &&
-			wizard.currentStep !== "string-paste",
+			wizard.currentStep !== "string-paste" &&
+			wizard.currentStep !== "advanced",
 	);
 	const showConnect = $derived(
 		wizard.currentStep === "credentials" ||
 			wizard.currentStep === "advanced" ||
 			(wizard.currentStep === "string-paste" && wizard.formData.name.trim()),
 	);
-	const showSkipAdvanced = $derived(wizard.currentStep === "credentials");
-
-	const isReconnecting = $derived(wizard.reconnectingConnectionId !== null);
+	const showSkipAdvanced = $derived(
+		wizard.currentStep === "credentials" && wizard.formData.type !== "sqlite",
+	);
 </script>
 
 <Dialog bind:open={wizard.isOpen}>


### PR DESCRIPTION
## Summary
- Remove Back button on reconnect dialog (first step only - can still go back from advanced options)
- Remove unused Next button on advanced options step
- Hide Advanced Options button for SQLite since it has no advanced options

## Test plan
- [ ] Open reconnect dialog and verify Back button is not shown on credentials step
- [ ] Click Advanced Options and verify Back button appears to return to credentials
- [ ] Verify Next button is not shown on advanced options step
- [ ] Test with SQLite connection - Advanced Options button should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)