### PR TITLE
Include database name in connection ID

### DIFF
--- a/src/lib/hooks/database/connection-manager.svelte.ts
+++ b/src/lib/hooks/database/connection-manager.svelte.ts
@@ -134,7 +134,7 @@ export class ConnectionManager {
     const connectionId =
       connection.type === "sqlite"
         ? `conn-sqlite-${connection.databaseName}`
-        : `conn-${connection.host}-${connection.port}`;
+        : `conn-${connection.host}-${connection.port}-${connection.databaseName}`;
 
     const { effectiveConnectionString, tunnelLocalPort } = await this.setupSshTunnel(
       connection,


### PR DESCRIPTION
## Summary
- Fixed issue where users couldn't add two connections to the same host with different databases
- Connection IDs now include the database name (e.g., `conn-localhost-5432-mydb` instead of `conn-localhost-5432`)

## Test plan
- [ ] Add a connection to `host:port/database1`
- [ ] Add a second connection to `host:port/database2`
- [ ] Verify both connections appear and work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)