### PR TITLE
Add browser demo mode with DuckDB WASM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /build
+/build-demo
 /.svelte-kit
 /package
 .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.8",
+        "@duckdb/duckdb-wasm": "^1.32.0",
         "@tanstack/svelte-virtual": "^3.13.13",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
@@ -75,6 +76,15 @@
       "license": "MIT",
       "engines": {
         "node": ">17.0.0"
+      }
+    },
+    "node_modules/@duckdb/duckdb-wasm": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.32.0.tgz",
+      "integrity": "sha512-IewXTNYEjsZCPE9weUWgtjGxUlMRo7qhX0GF6tq/KjK8bnY+RAl4cyUdYUfcdzbyb4b9ZxPC+FOsCcxgaKFWMg==",
+      "license": "MIT",
+      "dependencies": {
+        "apache-arrow": "^17.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1163,7 +1173,6 @@
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
       "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -1816,6 +1825,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1945,6 +1966,21 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/antlr4-c3": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/antlr4-c3/-/antlr4-c3-3.3.7.tgz",
@@ -1974,6 +2010,41 @@
         "antlr4ng": "index.js"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
+      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.cjs"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "20.19.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
+      "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1987,6 +2058,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/array-timsort": {
@@ -2159,6 +2239,37 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -2189,6 +2300,72 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
+      "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.0",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/commander": {
@@ -2611,6 +2788,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -2646,6 +2841,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/html-to-image": {
       "version": "1.11.13",
@@ -2730,6 +2934,14 @@
       "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -3030,6 +3242,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/lz-string": {
@@ -3775,6 +3993,18 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/svelte": {
       "version": "5.45.6",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.45.6.tgz",
@@ -3909,6 +4139,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -4024,7 +4276,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
@@ -4063,6 +4314,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/undici-types": {
@@ -4218,6 +4478,15 @@
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
+    "build:demo": "BUILD_TARGET=demo vite build --mode demo",
     "preview": "vite preview",
+    "preview:demo": "vite preview --outDir build-demo",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "tauri": "tauri",
@@ -17,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@dagrejs/dagre": "^1.1.8",
+    "@duckdb/duckdb-wasm": "^1.32.0",
     "@tanstack/svelte-virtual": "^3.13.13",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",

--- a/src/lib/components/app-header.svelte
+++ b/src/lib/components/app-header.svelte
@@ -16,8 +16,10 @@
     import LanguageToggle from "./language-toggle.svelte";
     import { connectionDialogStore } from "$lib/stores/connection-dialog.svelte.js";
     import { m } from "$lib/paraglide/messages.js";
+    import { getFeatures } from "$lib/features";
 
     const db = useDatabase();
+    const features = getFeatures();
     const sidebar = Sidebar.useSidebar();
 
     // Sort connections by last connected (most recent first)
@@ -36,7 +38,7 @@
 
     const handleConnectionClick = (connection: typeof db.state.connections[0]) => {
         // If connection has a database instance, just activate it
-        if (connection.database || connection.mssqlConnectionId) {
+        if (connection.database || connection.mssqlConnectionId || connection.providerConnectionId) {
             db.connections.setActive(connection.id);
         } else {
             // If no database (persisted connection), open dialog with prefilled values
@@ -93,7 +95,7 @@
                         <span
                             class={[
                                 "size-2 rounded-full shrink-0",
-                                (db.state.activeConnection.database || db.state.activeConnection.mssqlConnectionId) ? "bg-green-500" : "bg-gray-400"
+                                (db.state.activeConnection.database || db.state.activeConnection.mssqlConnectionId || db.state.activeConnection.providerConnectionId) ? "bg-green-500" : "bg-gray-400"
                             ]}
                         ></span>
                         <span class="max-w-32 truncate" title={db.state.activeConnection.name}>{db.state.activeConnection.name}</span>
@@ -112,9 +114,9 @@
                                         <span
                                             class={[
                                                 "size-2 rounded-full shrink-0",
-                                                (connection.database || connection.mssqlConnectionId) ? "bg-green-500" : "bg-gray-400"
+                                                (connection.database || connection.mssqlConnectionId || connection.providerConnectionId) ? "bg-green-500" : "bg-gray-400"
                                             ]}
-                                            title={(connection.database || connection.mssqlConnectionId) ? m.header_connected() : m.header_disconnected()}
+                                            title={(connection.database || connection.mssqlConnectionId || connection.providerConnectionId) ? m.header_connected() : m.header_disconnected()}
                                         ></span>
                                         <span class="flex-1 truncate">{connection.name}</span>
                                         {#if db.state.activeConnectionId === connection.id}
@@ -123,7 +125,7 @@
                                     </DropdownMenu.Item>
                                 </ContextMenu.Trigger>
                                 <ContextMenu.Content class="w-40">
-                                    {#if connection.database || connection.mssqlConnectionId}
+                                    {#if connection.database || connection.mssqlConnectionId || connection.providerConnectionId}
                                         <ContextMenu.Item onclick={() => db.connections.toggle(connection.id)}>
                                             {m.header_disconnect()}
                                         </ContextMenu.Item>
@@ -143,20 +145,22 @@
                                 </ContextMenu.Content>
                             </ContextMenu.Root>
                         {/each}
-                        <DropdownMenu.Separator />
-                        <DropdownMenu.Item
-                            class="flex items-center gap-2 cursor-pointer"
-                            onclick={() => connectionDialogStore.open()}
-                        >
-                            <PlusIcon class="size-4" />
-                            {m.header_add_connection()}
-                        </DropdownMenu.Item>
+                        {#if features.newConnections}
+                            <DropdownMenu.Separator />
+                            <DropdownMenu.Item
+                                class="flex items-center gap-2 cursor-pointer"
+                                onclick={() => connectionDialogStore.open()}
+                            >
+                                <PlusIcon class="size-4" />
+                                {m.header_add_connection()}
+                            </DropdownMenu.Item>
+                        {/if}
                     </DropdownMenu.Content>
                 </DropdownMenu.Root>
             {/if}
         </div>
         <div class="flex items-center gap-1">
-            {#if db.state.activeConnection?.database || db.state.activeConnection?.mssqlConnectionId}
+            {#if db.state.activeConnection?.database || db.state.activeConnection?.mssqlConnectionId || db.state.activeConnection?.providerConnectionId}
                 <Button
                     size="icon"
                     variant="ghost"

--- a/src/lib/components/command-palette.svelte
+++ b/src/lib/components/command-palette.svelte
@@ -35,7 +35,7 @@
 	const openTabs = $derived(db.tabs.ordered);
 	const activeResult = $derived(db.state.activeQueryResult);
 	const hasResults = $derived((activeResult?.rows?.length ?? 0) > 0);
-	const isConnected = $derived(!!db.state.activeConnectionId && !!(db.state.activeConnection?.database || db.state.activeConnection?.mssqlConnectionId));
+	const isConnected = $derived(!!db.state.activeConnectionId && !!(db.state.activeConnection?.database || db.state.activeConnection?.mssqlConnectionId || db.state.activeConnection?.providerConnectionId));
 	const hasActiveQueryTab = $derived(isConnected && !!db.state.activeQueryTab);
 	const hasQueryContent = $derived(hasActiveQueryTab && !!db.state.activeQueryTab?.query?.trim());
 	const hasConnections = $derived(connections.length > 0);
@@ -137,7 +137,7 @@
 		const connection = connections.find((c) => c.id === id);
 		if (!connection) return;
 
-		if (connection.database || connection.mssqlConnectionId) {
+		if (connection.database || connection.mssqlConnectionId || connection.providerConnectionId) {
 			// Already connected, just switch to it
 			runAndClose(() => db.connections.setActive(id));
 		} else {
@@ -370,7 +370,7 @@
 						</span>
 						{#if connection.id === db.state.activeConnectionId}
 							<span class="text-muted-foreground ms-auto text-xs">{m.command_status_active()}</span>
-						{:else if !(connection.database || connection.mssqlConnectionId)}
+						{:else if !(connection.database || connection.mssqlConnectionId || connection.providerConnectionId)}
 							<span class="text-muted-foreground ms-auto text-xs">{m.command_status_disconnected()}</span>
 						{/if}
 					</Command.Item>

--- a/src/lib/components/connection-dialog.svelte
+++ b/src/lib/components/connection-dialog.svelte
@@ -29,8 +29,10 @@
     import { toast } from "svelte-sonner";
     import CopyIcon from "@lucide/svelte/icons/copy";
     import { SshTunnelConfig } from "$lib/components/connection-dialog/index.js";
+    import { getFeatures } from "$lib/features";
 
     let { open = $bindable(false), prefill = undefined }: Props = $props();
+    const features = getFeatures();
     const db = useDatabase();
 
     let formData = $state({
@@ -123,7 +125,7 @@
 
     const sslModes = ["disable", "allow", "prefer", "require"];
 
-    const databaseTypes: {
+    const allDatabaseTypes: {
         value: DatabaseType;
         label: string;
         defaultPort: number;
@@ -166,6 +168,11 @@
             protocol: ["mssql", "sqlserver"],
         },
     ];
+
+    // Filter database types based on feature flags
+    const databaseTypes = features.mssqlSupport
+        ? allDatabaseTypes
+        : allDatabaseTypes.filter(t => t.value !== "mssql");
 
     const selectedDbType = $derived(
         databaseTypes.find((t) => t.value === formData.type),
@@ -626,26 +633,28 @@
                         </div>
                     {/if}
 
-                    <!-- SSH Tunnel Section -->
-                    <SshTunnelConfig
-                        enabled={formData.sshEnabled}
-                        host={formData.sshHost}
-                        port={formData.sshPort}
-                        username={formData.sshUsername}
-                        authMethod={formData.sshAuthMethod}
-                        password={formData.sshPassword}
-                        keyPath={formData.sshKeyPath}
-                        keyPassphrase={formData.sshKeyPassphrase}
-                        {isReconnecting}
-                        onEnabledChange={(v) => formData.sshEnabled = v}
-                        onHostChange={(v) => formData.sshHost = v}
-                        onPortChange={(v) => formData.sshPort = v}
-                        onUsernameChange={(v) => formData.sshUsername = v}
-                        onAuthMethodChange={(v) => formData.sshAuthMethod = v}
-                        onPasswordChange={(v) => formData.sshPassword = v}
-                        onKeyPathChange={(v) => formData.sshKeyPath = v}
-                        onKeyPassphraseChange={(v) => formData.sshKeyPassphrase = v}
-                    />
+                    <!-- SSH Tunnel Section (desktop only) -->
+                    {#if features.sshTunnels}
+                        <SshTunnelConfig
+                            enabled={formData.sshEnabled}
+                            host={formData.sshHost}
+                            port={formData.sshPort}
+                            username={formData.sshUsername}
+                            authMethod={formData.sshAuthMethod}
+                            password={formData.sshPassword}
+                            keyPath={formData.sshKeyPath}
+                            keyPassphrase={formData.sshKeyPassphrase}
+                            {isReconnecting}
+                            onEnabledChange={(v) => formData.sshEnabled = v}
+                            onHostChange={(v) => formData.sshHost = v}
+                            onPortChange={(v) => formData.sshPort = v}
+                            onUsernameChange={(v) => formData.sshUsername = v}
+                            onAuthMethodChange={(v) => formData.sshAuthMethod = v}
+                            onPasswordChange={(v) => formData.sshPassword = v}
+                            onKeyPathChange={(v) => formData.sshKeyPath = v}
+                            onKeyPassphraseChange={(v) => formData.sshKeyPassphrase = v}
+                        />
+                    {/if}
                 {/if}
             </TabsContent>
         </Tabs>

--- a/src/lib/components/empty-states/connection-card.svelte
+++ b/src/lib/components/empty-states/connection-card.svelte
@@ -16,7 +16,7 @@
 	const db = useDatabase();
 
 	const handleClick = () => {
-		if (connection.database) {
+		if (connection.database || connection.providerConnectionId) {
 			// Already connected, just activate
 			db.connections.setActive(connection.id);
 		} else {
@@ -52,9 +52,9 @@
 				<span
 					class={[
 						"size-2 rounded-full shrink-0",
-						connection.database ? "bg-green-500" : "bg-gray-400",
+						(connection.database || connection.providerConnectionId) ? "bg-green-500" : "bg-gray-400",
 					]}
-					title={connection.database ? m.empty_states_connection_card_connected() : m.empty_states_connection_card_disconnected()}
+					title={(connection.database || connection.providerConnectionId) ? m.empty_states_connection_card_connected() : m.empty_states_connection_card_disconnected()}
 				></span>
 				<DatabaseIcon class="size-4 text-muted-foreground" />
 				<Card.Title class="text-sm font-medium truncate">{connection.name}</Card.Title>

--- a/src/lib/components/theme-toggle.svelte
+++ b/src/lib/components/theme-toggle.svelte
@@ -5,9 +5,20 @@
     import { resetMode, setMode } from "mode-watcher";
     import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
     import { buttonVariants } from "$lib/components/ui/button/index.js";
-
-    import { setTheme } from "@tauri-apps/api/app";
+    import { isTauri } from "$lib/utils/environment";
     import { m } from "$lib/paraglide/messages.js";
+
+    async function handleSetMode(mode: "light" | "dark" | "system") {
+        if (isTauri()) {
+            const { setTheme } = await import("@tauri-apps/api/app");
+            await setTheme(mode === "system" ? null : mode);
+        }
+        if (mode === "system") {
+            resetMode();
+        } else {
+            setMode(mode);
+        }
+    }
 </script>
 
 <DropdownMenu.Root>
@@ -23,23 +34,8 @@
         <span class="sr-only">{m.theme_toggle()}</span>
     </DropdownMenu.Trigger>
     <DropdownMenu.Content align="end">
-        <DropdownMenu.Item
-            onclick={async () => {
-                await setTheme("light");
-                setMode("light");
-            }}>{m.theme_light()}</DropdownMenu.Item
-        >
-        <DropdownMenu.Item
-            onclick={async () => {
-                await setTheme("dark");
-                setMode("dark");
-            }}>{m.theme_dark()}</DropdownMenu.Item
-        >
-        <DropdownMenu.Item
-            onclick={async () => {
-                await setTheme(null);
-                resetMode();
-            }}>{m.theme_system()}</DropdownMenu.Item
-        >
+        <DropdownMenu.Item onclick={() => handleSetMode("light")}>{m.theme_light()}</DropdownMenu.Item>
+        <DropdownMenu.Item onclick={() => handleSetMode("dark")}>{m.theme_dark()}</DropdownMenu.Item>
+        <DropdownMenu.Item onclick={() => handleSetMode("system")}>{m.theme_system()}</DropdownMenu.Item>
     </DropdownMenu.Content>
 </DropdownMenu.Root>

--- a/src/lib/config/sample-queries.ts
+++ b/src/lib/config/sample-queries.ts
@@ -145,6 +145,26 @@ FROM your_table;`,
 			requiresTable: true,
 		},
 	],
+	duckdb: [
+		{
+			id: "duckdb-list-tables",
+			name: "List all tables",
+			description: "View all tables in your database",
+			query: `SELECT table_schema, table_name
+FROM information_schema.tables
+WHERE table_type = 'BASE TABLE'
+ORDER BY table_schema, table_name;`,
+		},
+		{
+			id: "duckdb-sample-data",
+			name: "Preview table data",
+			description: "View sample rows from a table",
+			query: `SELECT *
+FROM your_table
+LIMIT 10;`,
+			requiresTable: true,
+		},
+	],
 };
 
 export const savedQueryExample: SampleQuery = {

--- a/src/lib/db/duckdb.ts
+++ b/src/lib/db/duckdb.ts
@@ -1,0 +1,134 @@
+import type { DatabaseAdapter, ExplainNode } from './index';
+import { validateIdentifier } from './index';
+import type { SchemaTable, SchemaColumn, SchemaIndex, ForeignKeyRef } from '$lib/types';
+
+interface DuckDBSchemaRow {
+	schema_name: string;
+	table_name: string;
+}
+
+interface DuckDBColumnRow {
+	column_name: string;
+	data_type: string;
+	is_nullable: string;
+	column_default: string | null;
+}
+
+interface DuckDBForeignKeyRow {
+	column_name: string;
+	referenced_schema: string;
+	referenced_table: string;
+	referenced_column: string;
+}
+
+/**
+ * DuckDB adapter for SQL generation and result parsing.
+ * DuckDB uses PostgreSQL-compatible SQL syntax.
+ */
+export class DuckDBAdapter implements DatabaseAdapter {
+	getSchemaQuery(): string {
+		return `SELECT
+			table_schema AS schema_name,
+			table_name
+		FROM
+			information_schema.tables
+		WHERE
+			table_type = 'BASE TABLE'
+			AND table_schema NOT IN ('pg_catalog', 'information_schema')
+		ORDER BY
+			table_schema, table_name`;
+	}
+
+	getColumnsQuery(table: string, schema: string): string {
+		return `SELECT
+			column_name,
+			data_type,
+			is_nullable,
+			column_default
+		FROM information_schema.columns
+		WHERE table_name = '${validateIdentifier(table)}' AND table_schema = '${validateIdentifier(schema)}'
+		ORDER BY ordinal_position`;
+	}
+
+	getIndexesQuery(_table: string, _schema: string): string {
+		// DuckDB doesn't have traditional indexes exposed via information_schema
+		// Return empty result
+		return `SELECT NULL AS index_name WHERE 1=0`;
+	}
+
+	getForeignKeysQuery(table: string, schema: string): string {
+		// Query DuckDB's constraint information for foreign keys
+		return `SELECT
+			unnest(constraint_column_names) AS column_name,
+			split_part(unnest(constraint_column_names), '.', 1) AS source_column,
+			split_part(constraint_text, 'REFERENCES ', 2) AS ref_info
+		FROM duckdb_constraints()
+		WHERE constraint_type = 'FOREIGN KEY'
+			AND table_name = '${validateIdentifier(table)}'
+			AND schema_name = '${validateIdentifier(schema)}'`;
+	}
+
+	getExplainQuery(query: string, analyze: boolean): string {
+		const baseQuery = query.replace(/;$/, '');
+		// DuckDB supports EXPLAIN and EXPLAIN ANALYZE
+		return analyze ? `EXPLAIN ANALYZE ${baseQuery}` : `EXPLAIN ${baseQuery}`;
+	}
+
+	parseExplainResult(rows: unknown[], _analyze: boolean): ExplainNode {
+		// DuckDB returns explain as text rows
+		const lines = (rows as { explain_value?: string; 'QUERY PLAN'?: string }[])
+			.map((r) => r.explain_value || r['QUERY PLAN'] || '')
+			.filter((l) => l.trim());
+
+		const text = lines.join('\n');
+
+		return {
+			type: 'Query Plan',
+			label: text || 'No plan available'
+		};
+	}
+
+	parseSchemaResult(rows: unknown[]): SchemaTable[] {
+		return (rows as DuckDBSchemaRow[]).map((row) => ({
+			name: row.table_name,
+			schema: row.schema_name,
+			type: 'table' as const,
+			columns: [],
+			indexes: []
+		}));
+	}
+
+	parseColumnsResult(rows: unknown[], foreignKeys?: unknown[]): SchemaColumn[] {
+		// Build foreign key map from column name to reference
+		const fkMap = new Map<string, ForeignKeyRef>();
+		if (foreignKeys) {
+			for (const fk of foreignKeys as { column_name: string; ref_info: string }[]) {
+				// Parse ref_info which looks like "schema.table(column)"
+				const refInfo = fk.ref_info || '';
+				const match = refInfo.match(/^([^.]+)\.([^(]+)\(([^)]+)\)/);
+				if (match) {
+					fkMap.set(fk.column_name, {
+						referencedSchema: match[1],
+						referencedTable: match[2],
+						referencedColumn: match[3]
+					});
+				}
+			}
+		}
+
+		return (rows as DuckDBColumnRow[]).map((col) => ({
+			name: col.column_name,
+			type: col.data_type,
+			nullable: col.is_nullable === 'YES',
+			defaultValue: col.column_default || undefined,
+			isPrimaryKey: false, // DuckDB in-memory doesn't track PK metadata well
+			isForeignKey: fkMap.has(col.column_name),
+			foreignKeyRef: fkMap.get(col.column_name)
+		}));
+	}
+
+	parseIndexesResult(_rows: unknown[]): SchemaIndex[] {
+		// DuckDB doesn't expose index information in a standard way
+		return [];
+	}
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -2,6 +2,7 @@ import type { DatabaseType, SchemaTable, SchemaColumn, SchemaIndex } from "$lib/
 import { MssqlAdapter } from "./mssql";
 import { PostgresAdapter } from "./postgres";
 import { SqliteAdapter } from "./sqlite";
+import { DuckDBAdapter } from "./duckdb";
 
 export interface ExplainNode {
 	type: string;
@@ -60,6 +61,7 @@ const adapters: Partial<Record<DatabaseType, DatabaseAdapter>> = {
 	mssql: new MssqlAdapter(),
 	postgres: new PostgresAdapter(),
 	sqlite: new SqliteAdapter(),
+	duckdb: new DuckDBAdapter(),
 };
 
 export function getAdapter(type: DatabaseType): DatabaseAdapter {

--- a/src/lib/demo/init.ts
+++ b/src/lib/demo/init.ts
@@ -1,0 +1,72 @@
+/**
+ * Demo initialization logic.
+ * Sets up DuckDB with sample data when running in browser mode.
+ */
+
+import { getProvider, isDemo } from '$lib/providers';
+import type { DuckDBProvider } from '$lib/providers/duckdb-provider';
+import { SAMPLE_SCHEMA, SAMPLE_DATA } from './sample-data';
+
+/**
+ * Initialize the demo environment.
+ * Creates a DuckDB connection and loads sample data.
+ *
+ * @returns Connection ID if in demo mode, null otherwise
+ */
+export async function initializeDemo(): Promise<string | null> {
+	if (!isDemo()) {
+		return null;
+	}
+
+	const provider = (await getProvider()) as DuckDBProvider;
+
+	// Connect to in-memory DuckDB
+	const connectionId = await provider.connect({
+		type: 'duckdb',
+		databaseName: ':memory:'
+	});
+
+	// Load schema
+	const schemaStatements = SAMPLE_SCHEMA.split(';')
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+
+	for (const statement of schemaStatements) {
+		try {
+			await provider.execute(connectionId, statement);
+		} catch (error) {
+			console.warn('[Demo] Schema statement failed:', statement, error);
+		}
+	}
+
+	// Load data
+	const dataStatements = SAMPLE_DATA.split(';')
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+
+	for (const statement of dataStatements) {
+		try {
+			await provider.execute(connectionId, statement);
+		} catch (error) {
+			console.warn('[Demo] Data statement failed:', statement, error);
+		}
+	}
+
+	return connectionId;
+}
+
+/**
+ * Get a demo connection configuration for the UI.
+ */
+export function getDemoConnectionConfig() {
+	return {
+		id: 'demo-connection',
+		name: 'Demo Database',
+		type: 'duckdb' as const,
+		host: 'browser',
+		port: 0,
+		databaseName: 'demo',
+		username: '',
+		password: ''
+	};
+}

--- a/src/lib/demo/sample-data.ts
+++ b/src/lib/demo/sample-data.ts
@@ -1,0 +1,147 @@
+/**
+ * Sample e-commerce database schema and data for the browser demo.
+ */
+
+export const SAMPLE_SCHEMA = `
+-- Create schema
+CREATE SCHEMA IF NOT EXISTS demo;
+
+-- Customers table
+CREATE TABLE demo.customers (
+  id INTEGER PRIMARY KEY,
+  email VARCHAR(255) NOT NULL,
+  first_name VARCHAR(100),
+  last_name VARCHAR(100),
+  created_at TIMESTAMP,
+  country VARCHAR(2)
+);
+
+-- Products table
+CREATE TABLE demo.products (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  category VARCHAR(100),
+  price DECIMAL(10, 2),
+  stock_quantity INTEGER,
+  created_at TIMESTAMP
+);
+
+-- Orders table
+CREATE TABLE demo.orders (
+  id INTEGER PRIMARY KEY,
+  customer_id INTEGER REFERENCES demo.customers(id),
+  status VARCHAR(50),
+  total_amount DECIMAL(10, 2),
+  created_at TIMESTAMP,
+  shipped_at TIMESTAMP
+);
+
+-- Order items table (junction table for orders and products)
+CREATE TABLE demo.order_items (
+  id INTEGER PRIMARY KEY,
+  order_id INTEGER REFERENCES demo.orders(id),
+  product_id INTEGER REFERENCES demo.products(id),
+  quantity INTEGER,
+  unit_price DECIMAL(10, 2)
+);
+`;
+
+export const SAMPLE_DATA = `
+-- Insert customers
+INSERT INTO demo.customers VALUES (1, 'alice@example.com', 'Alice', 'Johnson', '2024-01-15 10:30:00', 'US');
+INSERT INTO demo.customers VALUES (2, 'bob@example.com', 'Bob', 'Smith', '2024-01-20 14:45:00', 'US');
+INSERT INTO demo.customers VALUES (3, 'carol@example.com', 'Carol', 'Williams', '2024-02-01 09:15:00', 'CA');
+INSERT INTO demo.customers VALUES (4, 'david@example.com', 'David', 'Brown', '2024-02-10 16:20:00', 'UK');
+INSERT INTO demo.customers VALUES (5, 'emma@example.com', 'Emma', 'Davis', '2024-02-15 11:00:00', 'DE');
+INSERT INTO demo.customers VALUES (6, 'frank@example.com', 'Frank', 'Miller', '2024-02-20 13:30:00', 'FR');
+INSERT INTO demo.customers VALUES (7, 'grace@example.com', 'Grace', 'Wilson', '2024-03-01 10:00:00', 'JP');
+INSERT INTO demo.customers VALUES (8, 'henry@example.com', 'Henry', 'Moore', '2024-03-05 15:45:00', 'AU');
+INSERT INTO demo.customers VALUES (9, 'iris@example.com', 'Iris', 'Taylor', '2024-03-10 08:30:00', 'US');
+INSERT INTO demo.customers VALUES (10, 'jack@example.com', 'Jack', 'Anderson', '2024-03-15 12:00:00', 'CA');
+
+-- Insert products
+INSERT INTO demo.products VALUES (1, 'Wireless Mouse', 'Electronics', 29.99, 150, '2024-01-01 00:00:00');
+INSERT INTO demo.products VALUES (2, 'Mechanical Keyboard', 'Electronics', 89.99, 75, '2024-01-01 00:00:00');
+INSERT INTO demo.products VALUES (3, 'USB-C Hub', 'Electronics', 49.99, 200, '2024-01-05 00:00:00');
+INSERT INTO demo.products VALUES (4, 'Monitor Stand', 'Accessories', 39.99, 100, '2024-01-10 00:00:00');
+INSERT INTO demo.products VALUES (5, 'Desk Lamp', 'Accessories', 24.99, 120, '2024-01-15 00:00:00');
+INSERT INTO demo.products VALUES (6, 'Webcam HD', 'Electronics', 69.99, 80, '2024-02-01 00:00:00');
+INSERT INTO demo.products VALUES (7, 'Headphones', 'Electronics', 149.99, 60, '2024-02-05 00:00:00');
+INSERT INTO demo.products VALUES (8, 'Mouse Pad XL', 'Accessories', 19.99, 300, '2024-02-10 00:00:00');
+INSERT INTO demo.products VALUES (9, 'Cable Organizer', 'Accessories', 12.99, 250, '2024-02-15 00:00:00');
+INSERT INTO demo.products VALUES (10, 'Laptop Stand', 'Accessories', 59.99, 90, '2024-02-20 00:00:00');
+INSERT INTO demo.products VALUES (11, 'External SSD 1TB', 'Storage', 99.99, 45, '2024-03-01 00:00:00');
+INSERT INTO demo.products VALUES (12, 'USB Flash Drive 64GB', 'Storage', 14.99, 500, '2024-03-05 00:00:00');
+
+-- Insert orders
+INSERT INTO demo.orders VALUES (1, 1, 'completed', 119.98, '2024-02-01 10:00:00', '2024-02-03 14:00:00');
+INSERT INTO demo.orders VALUES (2, 2, 'completed', 89.99, '2024-02-05 11:30:00', '2024-02-07 10:00:00');
+INSERT INTO demo.orders VALUES (3, 3, 'completed', 164.97, '2024-02-10 14:00:00', '2024-02-12 16:00:00');
+INSERT INTO demo.orders VALUES (4, 1, 'completed', 69.99, '2024-02-15 09:00:00', '2024-02-17 11:00:00');
+INSERT INTO demo.orders VALUES (5, 4, 'shipped', 249.97, '2024-03-01 16:00:00', '2024-03-03 10:00:00');
+INSERT INTO demo.orders VALUES (6, 5, 'processing', 139.98, '2024-03-10 10:30:00', NULL);
+INSERT INTO demo.orders VALUES (7, 6, 'processing', 79.98, '2024-03-12 14:45:00', NULL);
+INSERT INTO demo.orders VALUES (8, 7, 'pending', 199.98, '2024-03-15 09:15:00', NULL);
+INSERT INTO demo.orders VALUES (9, 2, 'pending', 59.99, '2024-03-16 11:00:00', NULL);
+INSERT INTO demo.orders VALUES (10, 8, 'pending', 114.98, '2024-03-17 15:30:00', NULL);
+
+-- Insert order items
+INSERT INTO demo.order_items VALUES (1, 1, 1, 2, 29.99);
+INSERT INTO demo.order_items VALUES (2, 1, 5, 2, 24.99);
+INSERT INTO demo.order_items VALUES (3, 2, 2, 1, 89.99);
+INSERT INTO demo.order_items VALUES (4, 3, 3, 1, 49.99);
+INSERT INTO demo.order_items VALUES (5, 3, 6, 1, 69.99);
+INSERT INTO demo.order_items VALUES (6, 3, 8, 2, 19.99);
+INSERT INTO demo.order_items VALUES (7, 4, 6, 1, 69.99);
+INSERT INTO demo.order_items VALUES (8, 5, 7, 1, 149.99);
+INSERT INTO demo.order_items VALUES (9, 5, 11, 1, 99.99);
+INSERT INTO demo.order_items VALUES (10, 6, 2, 1, 89.99);
+INSERT INTO demo.order_items VALUES (11, 6, 3, 1, 49.99);
+INSERT INTO demo.order_items VALUES (12, 7, 4, 2, 39.99);
+INSERT INTO demo.order_items VALUES (13, 8, 7, 1, 149.99);
+INSERT INTO demo.order_items VALUES (14, 8, 3, 1, 49.99);
+INSERT INTO demo.order_items VALUES (15, 9, 10, 1, 59.99);
+INSERT INTO demo.order_items VALUES (16, 10, 11, 1, 99.99);
+INSERT INTO demo.order_items VALUES (17, 10, 12, 1, 14.99);
+`;
+
+/**
+ * Example queries to show users what they can do.
+ */
+export const EXAMPLE_QUERIES = [
+	{
+		name: 'List all customers',
+		query: 'SELECT * FROM demo.customers ORDER BY created_at DESC;'
+	},
+	{
+		name: 'Products by category',
+		query: `SELECT category, COUNT(*) as count, AVG(price) as avg_price
+FROM demo.products
+GROUP BY category
+ORDER BY count DESC;`
+	},
+	{
+		name: 'Recent orders with customer info',
+		query: `SELECT o.id, c.first_name, c.last_name, o.status, o.total_amount, o.created_at
+FROM demo.orders o
+JOIN demo.customers c ON o.customer_id = c.id
+ORDER BY o.created_at DESC
+LIMIT 10;`
+	},
+	{
+		name: 'Top selling products',
+		query: `SELECT p.name, SUM(oi.quantity) as total_sold, SUM(oi.quantity * oi.unit_price) as revenue
+FROM demo.order_items oi
+JOIN demo.products p ON oi.product_id = p.id
+GROUP BY p.id, p.name
+ORDER BY total_sold DESC;`
+	},
+	{
+		name: 'Customer order summary',
+		query: `SELECT c.first_name, c.last_name, COUNT(o.id) as order_count, SUM(o.total_amount) as total_spent
+FROM demo.customers c
+LEFT JOIN demo.orders o ON c.id = o.customer_id
+GROUP BY c.id, c.first_name, c.last_name
+ORDER BY total_spent DESC;`
+	}
+];

--- a/src/lib/features/index.ts
+++ b/src/lib/features/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Feature flags for demo mode vs desktop app.
+ * Controls which features are available in each environment.
+ */
+
+import { isDemo as checkIsDemo } from '$lib/utils/environment';
+
+/**
+ * Feature flags interface.
+ */
+export interface FeatureFlags {
+	/** Allow creating new database connections */
+	newConnections: boolean;
+	/** Show SSH tunnel configuration options */
+	sshTunnels: boolean;
+	/** Show MSSQL connection option */
+	mssqlSupport: boolean;
+	/** Allow file export (CSV, JSON, etc.) */
+	fileExport: boolean;
+	/** Show app updater UI */
+	appUpdater: boolean;
+	/** Allow editing connection settings */
+	editConnections: boolean;
+	/** Show the AI assistant */
+	aiAssistant: boolean;
+	/** Allow saving queries */
+	savedQueries: boolean;
+	/** Show connection type selector */
+	connectionTypeSelector: boolean;
+}
+
+/**
+ * Get feature flags for the current environment.
+ */
+export function getFeatures(): FeatureFlags {
+	const demo = checkIsDemo();
+
+	return {
+		newConnections: !demo,
+		sshTunnels: !demo,
+		mssqlSupport: !demo,
+		fileExport: !demo, // Could enable with browser download API
+		appUpdater: !demo,
+		editConnections: !demo,
+		aiAssistant: true, // Works in demo
+		savedQueries: true, // Uses localStorage in demo
+		connectionTypeSelector: !demo
+	};
+}
+
+/**
+ * Check if a specific feature is enabled.
+ */
+export function isFeatureEnabled(feature: keyof FeatureFlags): boolean {
+	return getFeatures()[feature];
+}
+
+/**
+ * Check if running in demo mode.
+ */
+export function isDemo(): boolean {
+	return checkIsDemo();
+}

--- a/src/lib/hooks/database.svelte.ts
+++ b/src/lib/hooks/database.svelte.ts
@@ -1,5 +1,4 @@
 import { setContext, getContext } from "svelte";
-import type Database from "@tauri-apps/plugin-sql";
 import type { SchemaTable } from "$lib/types";
 import type { DatabaseAdapter } from "$lib/db";
 import { DatabaseState } from "./database/state.svelte.js";
@@ -80,8 +79,8 @@ class UseDatabase {
       this.persistence,
       this._stateRestoration,
       this.tabs,
-      (connectionId: string, schemas: SchemaTable[], adapter: DatabaseAdapter, database: Database | undefined, mssqlConnectionId?: string) => {
-        this.schemaTabs.loadTableMetadataInBackground(connectionId, schemas, adapter, database, mssqlConnectionId);
+      (connectionId: string, schemas: SchemaTable[], adapter: DatabaseAdapter, providerConnectionId?: string, mssqlConnectionId?: string) => {
+        this.schemaTabs.loadTableMetadataInBackground(connectionId, schemas, adapter, providerConnectionId, mssqlConnectionId);
       },
       () => this.queryTabs.add()
     );

--- a/src/lib/hooks/database/persistence-manager.svelte.ts
+++ b/src/lib/hooks/database/persistence-manager.svelte.ts
@@ -1,4 +1,3 @@
-import { load } from "@tauri-apps/plugin-store";
 import { toast } from "svelte-sonner";
 import type {
   PersistedConnectionState,
@@ -12,6 +11,7 @@ import type {
 } from "$lib/types";
 import type { DatabaseState } from "./state.svelte.js";
 import type { PersistedConnection } from "./types.js";
+import { loadStore, type Store } from "$lib/storage";
 
 /**
  * Manages persistence of connection state to Tauri store.
@@ -127,7 +127,7 @@ export class PersistenceManager {
 
   async persistConnectionState(connectionId: string): Promise<void> {
     try {
-      const store = await load(`connection_state_${connectionId}.json`, {
+      const store = await loadStore(`connection_state_${connectionId}.json`, {
         autoSave: true,
         defaults: { state: null },
       });
@@ -157,7 +157,7 @@ export class PersistenceManager {
 
   async loadPersistedConnectionState(connectionId: string): Promise<PersistedConnectionState | null> {
     try {
-      const store = await load(`connection_state_${connectionId}.json`, {
+      const store = await loadStore(`connection_state_${connectionId}.json`, {
         autoSave: false,
         defaults: { state: null },
       });
@@ -170,7 +170,7 @@ export class PersistenceManager {
 
   async removePersistedConnectionState(connectionId: string): Promise<void> {
     try {
-      const store = await load(`connection_state_${connectionId}.json`, {
+      const store = await loadStore(`connection_state_${connectionId}.json`, {
         autoSave: true,
         defaults: { state: null },
       });
@@ -213,7 +213,7 @@ export class PersistenceManager {
 
   async persistConnection(connection: DatabaseConnection): Promise<void> {
     try {
-      const store = await load("database_connections.json", {
+      const store = await loadStore("database_connections.json", {
         autoSave: true,
         defaults: { connections: [] },
       });
@@ -250,7 +250,7 @@ export class PersistenceManager {
 
   async removePersistedConnection(connectionId: string): Promise<void> {
     try {
-      const store = await load("database_connections.json", {
+      const store = await loadStore("database_connections.json", {
         autoSave: true,
         defaults: { connections: [] },
       });
@@ -269,7 +269,7 @@ export class PersistenceManager {
 
   async loadPersistedConnections(): Promise<PersistedConnection[]> {
     try {
-      const store = await load("database_connections.json", {
+      const store = await loadStore("database_connections.json", {
         autoSave: true,
         defaults: { connections: [] },
       });

--- a/src/lib/monaco/setup.ts
+++ b/src/lib/monaco/setup.ts
@@ -13,7 +13,13 @@ export async function initMonaco(): Promise<void> {
 				"monaco-editor/esm/vs/editor/editor.worker.js",
 				import.meta.url
 			);
-			return new Worker(workerUrl, { type: "module" });
+			const worker = new Worker(workerUrl, { type: "module" });
+			// Suppress worker errors (Monaco still works, just without some features)
+			worker.onerror = (e) => {
+				e.preventDefault();
+				console.debug("[Monaco] Worker failed to load, some features may be limited");
+			};
+			return worker;
 		}
 	};
 

--- a/src/lib/providers/duckdb-provider.ts
+++ b/src/lib/providers/duckdb-provider.ts
@@ -1,0 +1,148 @@
+/**
+ * DuckDB-WASM database provider.
+ * Runs an in-browser DuckDB instance for the web demo.
+ */
+
+import type { DatabaseProvider, ConnectionConfig, ExecuteResult } from './types';
+
+// DuckDB-WASM types - dynamically imported
+type AsyncDuckDB = import('@duckdb/duckdb-wasm').AsyncDuckDB;
+type AsyncDuckDBConnection = import('@duckdb/duckdb-wasm').AsyncDuckDBConnection;
+
+/**
+ * Database provider that uses DuckDB-WASM.
+ * Provides an in-browser SQL database for the demo.
+ */
+export class DuckDBProvider implements DatabaseProvider {
+	readonly id = 'duckdb';
+
+	private db: AsyncDuckDB | null = null;
+	private connections = new Map<string, AsyncDuckDBConnection>();
+	private initialized = false;
+	private initPromise: Promise<void> | null = null;
+
+	isAvailable(): boolean {
+		// Available in browser when not in Tauri
+		return typeof window !== 'undefined' && !('__TAURI__' in window);
+	}
+
+	/**
+	 * Initialize DuckDB-WASM. Called once before first connection.
+	 */
+	private async initialize(): Promise<void> {
+		if (this.initialized) return;
+		if (this.initPromise) return this.initPromise;
+
+		this.initPromise = this.doInitialize();
+		await this.initPromise;
+	}
+
+	private async doInitialize(): Promise<void> {
+		const duckdb = await import('@duckdb/duckdb-wasm');
+
+		// Use jsDelivr CDN for WASM bundles
+		const JSDELIVR_BUNDLES = duckdb.getJsDelivrBundles();
+		const bundle = await duckdb.selectBundle(JSDELIVR_BUNDLES);
+
+		// Create worker
+		const workerUrl = URL.createObjectURL(
+			new Blob([`importScripts("${bundle.mainWorker}");`], { type: 'text/javascript' })
+		);
+		const worker = new Worker(workerUrl);
+		const logger = new duckdb.ConsoleLogger();
+
+		// Instantiate database
+		this.db = new duckdb.AsyncDuckDB(logger, worker);
+		await this.db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+
+		this.initialized = true;
+	}
+
+	async connect(config: ConnectionConfig): Promise<string> {
+		await this.initialize();
+
+		if (!this.db) {
+			throw new Error('DuckDB not initialized');
+		}
+
+		const connectionId = `duckdb-${Date.now()}`;
+		const conn = await this.db.connect();
+		this.connections.set(connectionId, conn);
+
+		return connectionId;
+	}
+
+	async disconnect(connectionId: string): Promise<void> {
+		const conn = this.connections.get(connectionId);
+		if (conn) {
+			await conn.close();
+			this.connections.delete(connectionId);
+		}
+	}
+
+	async select<T = Record<string, unknown>>(connectionId: string, sql: string): Promise<T[]> {
+		const conn = this.connections.get(connectionId);
+		if (!conn) {
+			throw new Error(`Connection not found: ${connectionId}`);
+		}
+
+		const result = await conn.query(sql);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		return result.toArray().map((row: any) => row.toJSON() as T);
+	}
+
+	async execute(connectionId: string, sql: string, _params?: unknown[]): Promise<ExecuteResult> {
+		const conn = this.connections.get(connectionId);
+		if (!conn) {
+			throw new Error(`Connection not found: ${connectionId}`);
+		}
+
+		// DuckDB-WASM doesn't support parameterized queries in the same way
+		// For the demo, we execute the SQL directly
+		const result = await conn.query(sql);
+
+		return {
+			rowsAffected: result.numRows
+		};
+	}
+
+	async test(_config: ConnectionConfig): Promise<void> {
+		await this.initialize();
+
+		if (!this.db) {
+			throw new Error('DuckDB not initialized');
+		}
+
+		// Test by creating and closing a connection
+		const conn = await this.db.connect();
+		await conn.close();
+	}
+
+	/**
+	 * Execute raw SQL on a connection.
+	 * Useful for loading sample data with multiple statements.
+	 */
+	async executeRaw(connectionId: string, sql: string): Promise<void> {
+		const conn = this.connections.get(connectionId);
+		if (!conn) {
+			throw new Error(`Connection not found: ${connectionId}`);
+		}
+		await conn.query(sql);
+	}
+
+	/**
+	 * Get the underlying DuckDB instance.
+	 * Used for advanced operations like loading Parquet files.
+	 */
+	getDb(): AsyncDuckDB | null {
+		return this.db;
+	}
+
+	/**
+	 * Get the underlying connection.
+	 * Used for advanced operations.
+	 */
+	getConnection(connectionId: string): AsyncDuckDBConnection | undefined {
+		return this.connections.get(connectionId);
+	}
+}

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Database provider factory.
+ * Returns the appropriate provider based on the runtime environment.
+ */
+
+import type { DatabaseProvider } from './types';
+import { isTauri } from '$lib/utils/environment';
+
+export type { DatabaseProvider, ConnectionConfig, ExecuteResult } from './types';
+
+let provider: DatabaseProvider | null = null;
+
+/**
+ * Get the database provider for the current environment.
+ * Returns TauriDatabaseProvider in desktop app, DuckDBProvider in browser.
+ */
+export async function getProvider(): Promise<DatabaseProvider> {
+	if (provider) return provider;
+
+	if (isTauri()) {
+		const { TauriDatabaseProvider } = await import('./tauri-provider');
+		provider = new TauriDatabaseProvider();
+	} else {
+		const { DuckDBProvider } = await import('./duckdb-provider');
+		provider = new DuckDBProvider();
+	}
+
+	return provider;
+}
+
+/**
+ * Check if we're in demo mode (browser, not Tauri).
+ */
+export function isDemo(): boolean {
+	return !isTauri();
+}
+
+/**
+ * Reset the provider instance.
+ * Mainly useful for testing.
+ */
+export function resetProvider(): void {
+	provider = null;
+}

--- a/src/lib/providers/tauri-provider.ts
+++ b/src/lib/providers/tauri-provider.ts
@@ -1,0 +1,77 @@
+/**
+ * Tauri database provider.
+ * Wraps tauri-plugin-sql for PostgreSQL and SQLite connections in the desktop app.
+ */
+
+import Database from '@tauri-apps/plugin-sql';
+import type { DatabaseProvider, ConnectionConfig, ExecuteResult } from './types';
+
+/**
+ * Database provider that uses Tauri's SQL plugin.
+ * Supports PostgreSQL and SQLite via connection strings.
+ */
+export class TauriDatabaseProvider implements DatabaseProvider {
+	readonly id = 'tauri';
+
+	/** Map of connection IDs to Database instances */
+	private connections = new Map<string, Database>();
+
+	isAvailable(): boolean {
+		return typeof window !== 'undefined' && '__TAURI__' in window;
+	}
+
+	async connect(config: ConnectionConfig): Promise<string> {
+		if (!config.connectionString) {
+			throw new Error('Connection string is required for Tauri provider');
+		}
+
+		const connectionId = `tauri-${config.type}-${Date.now()}`;
+		const db = await Database.load(config.connectionString);
+		this.connections.set(connectionId, db);
+		return connectionId;
+	}
+
+	async disconnect(connectionId: string): Promise<void> {
+		const db = this.connections.get(connectionId);
+		if (db) {
+			await db.close();
+			this.connections.delete(connectionId);
+		}
+	}
+
+	async select<T = Record<string, unknown>>(connectionId: string, sql: string): Promise<T[]> {
+		const db = this.connections.get(connectionId);
+		if (!db) {
+			throw new Error(`Connection not found: ${connectionId}`);
+		}
+		return db.select(sql) as Promise<T[]>;
+	}
+
+	async execute(connectionId: string, sql: string, params?: unknown[]): Promise<ExecuteResult> {
+		const db = this.connections.get(connectionId);
+		if (!db) {
+			throw new Error(`Connection not found: ${connectionId}`);
+		}
+		const result = await db.execute(sql, params);
+		return {
+			rowsAffected: result?.rowsAffected ?? 0,
+			lastInsertId: result?.lastInsertId
+		};
+	}
+
+	async test(config: ConnectionConfig): Promise<void> {
+		if (!config.connectionString) {
+			throw new Error('Connection string is required for Tauri provider');
+		}
+		const db = await Database.load(config.connectionString);
+		await db.close();
+	}
+
+	/**
+	 * Get the underlying Database instance for a connection.
+	 * Used for backward compatibility during migration.
+	 */
+	getDatabase(connectionId: string): Database | undefined {
+		return this.connections.get(connectionId);
+	}
+}

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,0 +1,89 @@
+/**
+ * Database provider abstraction layer.
+ * Enables the same codebase to work with Tauri (desktop) and DuckDB-WASM (web).
+ */
+
+import type { DatabaseType } from '$lib/types';
+
+/**
+ * Configuration for establishing a database connection.
+ */
+export interface ConnectionConfig {
+	/** Database engine type */
+	type: DatabaseType;
+	/** Database server hostname */
+	host?: string;
+	/** Database server port */
+	port?: number;
+	/** Database name */
+	databaseName: string;
+	/** Username for authentication */
+	username?: string;
+	/** Password for authentication */
+	password?: string;
+	/** Full connection string (used by Tauri for PostgreSQL/SQLite) */
+	connectionString?: string;
+	/** SSL mode */
+	sslMode?: string;
+}
+
+/**
+ * Result of an execute operation (INSERT, UPDATE, DELETE).
+ */
+export interface ExecuteResult {
+	/** Number of rows affected by the operation */
+	rowsAffected: number;
+	/** ID of the last inserted row (if applicable) */
+	lastInsertId?: number;
+}
+
+/**
+ * Unified interface for database operations.
+ * Implementations handle the specifics of each backend (Tauri, DuckDB-WASM).
+ */
+export interface DatabaseProvider {
+	/** Provider identifier */
+	readonly id: string;
+
+	/**
+	 * Check if this provider is available in the current environment.
+	 */
+	isAvailable(): boolean;
+
+	/**
+	 * Establish a database connection.
+	 * @param config Connection configuration
+	 * @returns Connection ID for subsequent operations
+	 */
+	connect(config: ConnectionConfig): Promise<string>;
+
+	/**
+	 * Close a database connection.
+	 * @param connectionId Connection ID from connect()
+	 */
+	disconnect(connectionId: string): Promise<void>;
+
+	/**
+	 * Execute a SELECT query and return rows.
+	 * @param connectionId Connection ID from connect()
+	 * @param sql SQL query to execute
+	 * @returns Array of result rows
+	 */
+	select<T = Record<string, unknown>>(connectionId: string, sql: string): Promise<T[]>;
+
+	/**
+	 * Execute a write query (INSERT, UPDATE, DELETE).
+	 * @param connectionId Connection ID from connect()
+	 * @param sql SQL query to execute
+	 * @param params Optional parameterized query values
+	 * @returns Execute result with rowsAffected
+	 */
+	execute(connectionId: string, sql: string, params?: unknown[]): Promise<ExecuteResult>;
+
+	/**
+	 * Test a connection without persisting it.
+	 * @param config Connection configuration
+	 * @throws Error if connection fails
+	 */
+	test(config: ConnectionConfig): Promise<void>;
+}

--- a/src/lib/services/dbeaver-import.ts
+++ b/src/lib/services/dbeaver-import.ts
@@ -30,6 +30,7 @@ const DEFAULT_PORTS: Record<DatabaseType, number> = {
 	sqlite: 0,
 	mongodb: 27017,
 	mssql: 1433,
+	duckdb: 0,
 };
 
 /**

--- a/src/lib/shortcuts/platform.ts
+++ b/src/lib/shortcuts/platform.ts
@@ -1,10 +1,38 @@
-import { platform } from "@tauri-apps/plugin-os";
+import { isTauri } from "$lib/utils/environment";
 
 let cachedPlatform: string | null = null;
 
+function detectPlatform(): string {
+	if (isTauri()) {
+		// Use Tauri plugin for accurate detection in desktop app
+		// This will be called synchronously, so we need to handle it carefully
+		try {
+			// Dynamic import won't work synchronously, so use navigator as fallback
+			if (typeof navigator !== "undefined") {
+				const ua = navigator.userAgent.toLowerCase();
+				if (ua.includes("mac")) return "macos";
+				if (ua.includes("win")) return "windows";
+				if (ua.includes("linux")) return "linux";
+			}
+		} catch {
+			// Fall through to browser detection
+		}
+	}
+
+	// Browser detection using navigator
+	if (typeof navigator !== "undefined") {
+		const ua = navigator.userAgent.toLowerCase();
+		if (ua.includes("mac")) return "macos";
+		if (ua.includes("win")) return "windows";
+		if (ua.includes("linux")) return "linux";
+	}
+
+	return "unknown";
+}
+
 export function isMac(): boolean {
 	if (cachedPlatform === null) {
-		cachedPlatform = platform();
+		cachedPlatform = detectPlatform();
 	}
 	return cachedPlatform === "macos";
 }

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Storage provider factory.
+ * Returns the appropriate storage provider based on the runtime environment.
+ */
+
+import type { StorageProvider, Store, StoreLoadOptions } from './types';
+import { isTauri } from '$lib/utils/environment';
+
+export type { StorageProvider, Store, StoreLoadOptions } from './types';
+
+let provider: StorageProvider | null = null;
+
+/**
+ * Get the storage provider for the current environment.
+ * Returns TauriStorageProvider in desktop app, WebStorageProvider in browser.
+ */
+export async function getStorageProvider(): Promise<StorageProvider> {
+	if (provider) return provider;
+
+	if (isTauri()) {
+		const { TauriStorageProvider } = await import('./tauri-storage');
+		provider = new TauriStorageProvider();
+	} else {
+		const { WebStorageProvider } = await import('./web-storage');
+		provider = new WebStorageProvider();
+	}
+
+	return provider;
+}
+
+/**
+ * Convenience function to load a store directly.
+ * Uses the appropriate storage provider for the current environment.
+ */
+export async function loadStore(name: string, options?: StoreLoadOptions): Promise<Store> {
+	const storageProvider = await getStorageProvider();
+	return storageProvider.load(name, options);
+}
+
+/**
+ * Reset the storage provider instance.
+ * Mainly useful for testing.
+ */
+export function resetStorageProvider(): void {
+	provider = null;
+}

--- a/src/lib/storage/tauri-storage.ts
+++ b/src/lib/storage/tauri-storage.ts
@@ -1,0 +1,53 @@
+/**
+ * Tauri storage provider.
+ * Wraps @tauri-apps/plugin-store for desktop app persistence.
+ */
+
+import { load as tauriLoad } from '@tauri-apps/plugin-store';
+import type { StorageProvider, Store, StoreLoadOptions } from './types';
+
+/**
+ * Wraps a Tauri store to implement the Store interface.
+ */
+class TauriStore implements Store {
+	constructor(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		private store: Awaited<ReturnType<typeof tauriLoad>>
+	) {}
+
+	async get<T>(key: string): Promise<T | null> {
+		return (await this.store.get(key)) as T | null;
+	}
+
+	async set<T>(key: string, value: T): Promise<void> {
+		await this.store.set(key, value);
+	}
+
+	async save(): Promise<void> {
+		await this.store.save();
+	}
+
+	async clear(): Promise<void> {
+		await this.store.clear();
+	}
+}
+
+/**
+ * Storage provider that uses Tauri's store plugin.
+ * Stores data in JSON files in the app data directory.
+ */
+export class TauriStorageProvider implements StorageProvider {
+	readonly id = 'tauri';
+
+	isAvailable(): boolean {
+		return typeof window !== 'undefined' && '__TAURI__' in window;
+	}
+
+	async load(name: string, options?: StoreLoadOptions): Promise<Store> {
+		const store = await tauriLoad(name, {
+			autoSave: options?.autoSave ?? true,
+			defaults: options?.defaults ?? {}
+		});
+		return new TauriStore(store);
+	}
+}

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Storage provider abstraction layer.
+ * Enables the same persistence code to work with Tauri store (desktop) and localStorage (web).
+ */
+
+/**
+ * Interface for a key-value store.
+ * Provides a consistent API for both Tauri store and web localStorage.
+ */
+export interface Store {
+	/**
+	 * Get a value from the store.
+	 * @param key The key to retrieve
+	 * @returns The value, or null if not found
+	 */
+	get<T>(key: string): Promise<T | null>;
+
+	/**
+	 * Set a value in the store.
+	 * @param key The key to set
+	 * @param value The value to store
+	 */
+	set<T>(key: string, value: T): Promise<void>;
+
+	/**
+	 * Save the store to persistent storage.
+	 * For web, this is a no-op since localStorage is synchronous.
+	 */
+	save(): Promise<void>;
+
+	/**
+	 * Clear all data in the store.
+	 */
+	clear(): Promise<void>;
+}
+
+/**
+ * Options for loading a store.
+ */
+export interface StoreLoadOptions {
+	/** Whether to auto-save after each set operation */
+	autoSave?: boolean;
+	/** Default values for the store */
+	defaults?: Record<string, unknown>;
+}
+
+/**
+ * Interface for the storage provider.
+ * Provides a factory method to create stores.
+ */
+export interface StorageProvider {
+	/**
+	 * Provider identifier.
+	 */
+	readonly id: string;
+
+	/**
+	 * Check if this provider is available in the current environment.
+	 */
+	isAvailable(): boolean;
+
+	/**
+	 * Load or create a store with the given name.
+	 * @param name The name of the store (used as filename for Tauri, key prefix for web)
+	 * @param options Store options
+	 * @returns A Store instance
+	 */
+	load(name: string, options?: StoreLoadOptions): Promise<Store>;
+}

--- a/src/lib/storage/web-storage.ts
+++ b/src/lib/storage/web-storage.ts
@@ -1,0 +1,121 @@
+/**
+ * Web storage provider.
+ * Uses localStorage for browser demo persistence.
+ */
+
+import type { StorageProvider, Store, StoreLoadOptions } from './types';
+
+/**
+ * Implements the Store interface using localStorage.
+ * Each store gets a prefix to namespace its keys.
+ */
+class WebStore implements Store {
+	private prefix: string;
+	private cache: Map<string, unknown>;
+
+	constructor(name: string, defaults?: Record<string, unknown>) {
+		// Use the store name as a prefix, removing .json extension if present
+		this.prefix = `seaquel_${name.replace('.json', '')}_`;
+		this.cache = new Map();
+
+		// Load existing data from localStorage into cache
+		this.loadFromLocalStorage();
+
+		// Apply defaults for missing keys
+		if (defaults) {
+			for (const [key, value] of Object.entries(defaults)) {
+				if (!this.cache.has(key)) {
+					this.cache.set(key, value);
+				}
+			}
+		}
+	}
+
+	private loadFromLocalStorage(): void {
+		try {
+			for (let i = 0; i < localStorage.length; i++) {
+				const fullKey = localStorage.key(i);
+				if (fullKey && fullKey.startsWith(this.prefix)) {
+					const key = fullKey.slice(this.prefix.length);
+					const value = localStorage.getItem(fullKey);
+					if (value !== null) {
+						try {
+							this.cache.set(key, JSON.parse(value));
+						} catch {
+							// If JSON parse fails, store as string
+							this.cache.set(key, value);
+						}
+					}
+				}
+			}
+		} catch (error) {
+			console.error('Failed to load from localStorage:', error);
+		}
+	}
+
+	async get<T>(key: string): Promise<T | null> {
+		const value = this.cache.get(key);
+		return value !== undefined ? (value as T) : null;
+	}
+
+	async set<T>(key: string, value: T): Promise<void> {
+		this.cache.set(key, value);
+		// Auto-save to localStorage
+		try {
+			localStorage.setItem(this.prefix + key, JSON.stringify(value));
+		} catch (error) {
+			console.error('Failed to save to localStorage:', error);
+		}
+	}
+
+	async save(): Promise<void> {
+		// No-op for web storage - we save on every set
+		// But sync all cached values to localStorage just in case
+		try {
+			for (const [key, value] of this.cache.entries()) {
+				localStorage.setItem(this.prefix + key, JSON.stringify(value));
+			}
+		} catch (error) {
+			console.error('Failed to save to localStorage:', error);
+		}
+	}
+
+	async clear(): Promise<void> {
+		// Remove all keys with our prefix
+		try {
+			const keysToRemove: string[] = [];
+			for (let i = 0; i < localStorage.length; i++) {
+				const fullKey = localStorage.key(i);
+				if (fullKey && fullKey.startsWith(this.prefix)) {
+					keysToRemove.push(fullKey);
+				}
+			}
+			for (const key of keysToRemove) {
+				localStorage.removeItem(key);
+			}
+			this.cache.clear();
+		} catch (error) {
+			console.error('Failed to clear localStorage:', error);
+		}
+	}
+}
+
+/**
+ * Storage provider that uses localStorage.
+ * Suitable for browser demo mode.
+ */
+export class WebStorageProvider implements StorageProvider {
+	readonly id = 'web';
+
+	isAvailable(): boolean {
+		try {
+			return typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+		} catch {
+			return false;
+		}
+	}
+
+	async load(name: string, options?: StoreLoadOptions): Promise<Store> {
+		return new WebStore(name, options?.defaults);
+	}
+}

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -1,4 +1,4 @@
-import { load } from "@tauri-apps/plugin-store";
+import { loadStore } from "$lib/storage";
 import { mode } from "mode-watcher";
 import type {
 	Theme,
@@ -54,7 +54,7 @@ class ThemeStore {
 	 */
 	async initialize(): Promise<void> {
 		try {
-			const store = await load(STORE_FILE, {
+			const store = await loadStore(STORE_FILE, {
 				autoSave: false,
 				defaults: {
 					preferences: DEFAULT_PREFERENCES,
@@ -284,7 +284,7 @@ class ThemeStore {
 
 	private async persist(): Promise<void> {
 		try {
-			const store = await load(STORE_FILE, {
+			const store = await loadStore(STORE_FILE, {
 				autoSave: true,
 				defaults: {
 					preferences: DEFAULT_PREFERENCES,

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -8,7 +8,7 @@ import type Database from '@tauri-apps/plugin-sql';
 /**
  * Supported database engine types.
  */
-export type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'mariadb' | 'mssql';
+export type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'mariadb' | 'mssql' | 'duckdb';
 
 /**
  * SSH tunnel authentication methods.
@@ -70,7 +70,9 @@ export interface DatabaseConnection {
 	connectionString?: string;
 	/** Timestamp of last successful connection */
 	lastConnected?: Date;
-	/** Active database connection handle (tauri-plugin-sql) */
+	/** Provider connection ID for database operations */
+	providerConnectionId?: string;
+	/** @deprecated Use providerConnectionId. Active database connection handle (tauri-plugin-sql) */
 	database?: Database;
 	/** Connection ID for MSSQL (uses custom Rust backend) */
 	mssqlConnectionId?: string;

--- a/src/lib/utils/environment.ts
+++ b/src/lib/utils/environment.ts
@@ -1,0 +1,38 @@
+/**
+ * Environment detection utilities.
+ * Used to determine runtime context (Tauri desktop vs web browser).
+ */
+
+/**
+ * Check if running inside Tauri desktop app.
+ * Uses __TAURI_INTERNALS__ which is available synchronously in Tauri v2,
+ * or falls back to checking __TAURI__ for compatibility.
+ */
+export function isTauri(): boolean {
+	if (typeof window === 'undefined') return false;
+
+	// __TAURI_INTERNALS__ is available synchronously in Tauri v2
+	if ('__TAURI_INTERNALS__' in window) return true;
+
+	// Fallback: check for __TAURI__ (may be async in some cases)
+	if ('__TAURI__' in window) return true;
+
+	// Check if loaded via tauri:// protocol (Tauri v2 default)
+	if (window.location.protocol === 'tauri:') return true;
+
+	return false;
+}
+
+/**
+ * Check if running in browser demo mode (not Tauri).
+ */
+export function isDemo(): boolean {
+	return !isTauri();
+}
+
+/**
+ * Check if running in a browser environment (vs SSR).
+ */
+export function isBrowser(): boolean {
+	return typeof window !== 'undefined';
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -4,13 +4,20 @@
 import adapter from "@sveltejs/adapter-static";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
+const isDemo = process.env.BUILD_TARGET === "demo";
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter({
       fallback: "index.html",
+      pages: isDemo ? "build-demo" : "build",
+      assets: isDemo ? "build-demo" : "build",
     }),
+    paths: {
+      base: isDemo ? "/demo" : "",
+    },
     alias: {
       $lib: "src/lib",
       "$lib/*": "src/lib/*",

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,33 +4,66 @@ import { defineConfig } from "vite";
 import { sveltekit } from "@sveltejs/kit/vite";
 
 const host = process.env.TAURI_DEV_HOST;
+const isDemo = process.env.BUILD_TARGET === "demo";
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => ({
-  plugins: [
-    tailwindcss(),
-    sveltekit(),
-    paraglideVitePlugin({ project: "./project.inlang", outdir: "./src/lib/paraglide" })
-  ],
+export default defineConfig(async ({ mode }) => {
+  const isDemoMode = mode === "demo" || isDemo;
 
-  // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
-  //
-  // 1. prevent vite from obscuring rust errors
-  clearScreen: false,
+  return {
+    plugins: [
+      tailwindcss(),
+      sveltekit(),
+      paraglideVitePlugin({ project: "./project.inlang", outdir: "./src/lib/paraglide" })
+    ],
 
-  // 2. tauri expects a fixed port, fail if that port is not available
-  server: {
-    port: 1420,
-    strictPort: true,
-    host: host || false,
-    hmr: host ? { protocol: "ws", host, port: 1421 } : undefined,
+    // Define environment variables
+    define: {
+      "import.meta.env.VITE_IS_DEMO": JSON.stringify(isDemoMode)
+    },
 
-    watch: {
-      // 3. tell vite to ignore watching `src-tauri`
-      ignored: ["**/src-tauri/**"]
-    }
-  },
+    // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
+    // Skip Tauri-specific config in demo mode
+    ...(isDemoMode
+      ? {}
+      : {
+          // 1. prevent vite from obscuring rust errors
+          clearScreen: false,
 
-  // Monaco Editor optimization
-  optimizeDeps: { include: ["monaco-editor", "monaco-sql-languages"] }
-}));
+          // 2. tauri expects a fixed port, fail if that port is not available
+          server: {
+            port: 1420,
+            strictPort: true,
+            host: host || false,
+            hmr: host ? { protocol: "ws", host, port: 1421 } : undefined,
+
+            watch: {
+              // 3. tell vite to ignore watching `src-tauri`
+              ignored: ["**/src-tauri/**"]
+            }
+          }
+        }),
+
+    // Monaco Editor and DuckDB optimization
+    optimizeDeps: {
+      include: ["monaco-editor", "monaco-sql-languages"],
+      // Include DuckDB-WASM in demo mode
+      ...(isDemoMode ? { include: ["monaco-editor", "monaco-sql-languages", "@duckdb/duckdb-wasm"] } : {})
+    },
+
+    // Build configuration for demo mode
+    build: isDemoMode
+      ? {
+          outDir: "build-demo",
+          // Externalize Tauri packages in demo mode (they won't be used)
+          rollupOptions: {
+            external: (/** @type {string} */ id) => {
+              // Don't externalize - let the dynamic imports handle it
+              // The environment checks will prevent Tauri code from running
+              return false;
+            }
+          }
+        }
+      : {}
+  };
+});


### PR DESCRIPTION
## Summary
- Adds the ability to run Seaquel in a browser without Tauri, using DuckDB WASM as the database backend
- Enables a web-based demo for users to try the app before downloading
- Adds provider and storage abstraction layers to support both Tauri and browser contexts

## Changes
- Add DuckDB WASM provider for browser-based SQL execution
- Add provider abstraction layer (Tauri provider vs DuckDB WASM provider)
- Add storage abstraction layer (Tauri store vs localStorage)
- Add environment detection utilities (`isTauri`, `isDemo`, `isBrowser`)
- Add demo initialization with sample employee/department data
- Update components to handle both Tauri and browser contexts
- Add `build:demo` and `preview:demo` npm scripts

## Test plan
- [ ] Run `npm run build:demo` and verify it builds successfully
- [ ] Run `npm run preview:demo` and verify the demo works in browser
- [ ] Verify sample data loads and queries execute correctly
- [ ] Verify `npm run tauri dev` still works for desktop mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)