### PR TITLE
Add parameter dialog support for Explain and Explain Analyze queries

### DIFF
--- a/src/lib/hooks/database/explain-tabs.svelte.ts
+++ b/src/lib/hooks/database/explain-tabs.svelte.ts
@@ -1,9 +1,10 @@
 import { toast } from 'svelte-sonner';
-import type { ExplainTab, ExplainResult, ExplainPlanNode } from '$lib/types';
+import type { ExplainTab, ExplainResult, ExplainPlanNode, ParameterValue } from '$lib/types';
 import type { DatabaseState } from './state.svelte.js';
 import type { TabOrderingManager } from './tab-ordering.svelte.js';
 import { getAdapter, type ExplainNode } from '$lib/db';
 import { getStatementAtOffset } from '$lib/db/sql-parser';
+import { substituteParameters } from '$lib/db/query-params';
 import { getProvider } from '$lib/providers';
 
 /**
@@ -134,6 +135,144 @@ export class ExplainTabManager {
 			}
 
 			const result = await provider.select(providerConnectionId, explainQuery);
+
+			// Use adapter to parse the results into common format
+			const parsedNode = adapter.parseExplainResult(result, analyze);
+
+			// For SQLite analyze, inject the actual execution stats into the root node
+			if (dbType === 'sqlite' && analyze && actualRowCount !== undefined) {
+				parsedNode.actualRows = actualRowCount;
+				parsedNode.rows = actualRowCount;
+				parsedNode.actualTime = executionTime;
+			}
+
+			// Convert to ExplainResult format for rendering
+			const explainResult: ExplainResult = this.convertExplainNodeToResult(parsedNode, analyze);
+
+			// For SQLite analyze, set execution time on the result
+			if (dbType === 'sqlite' && analyze && executionTime !== undefined) {
+				explainResult.executionTime = executionTime;
+			}
+
+			// Update the explain tab with results
+			newExplainTab.result = explainResult;
+			newExplainTab.isExecuting = false;
+
+			// Trigger reactivity by creating new array
+			const currentTabs = this.state.explainTabsByConnection[connectionId] ?? [];
+			this.state.explainTabsByConnection = {
+				...this.state.explainTabsByConnection,
+				[connectionId]: [...currentTabs]
+			};
+		} catch (error) {
+			// Remove failed explain tab
+			const currentTabs = this.state.explainTabsByConnection[connectionId] ?? [];
+			this.state.explainTabsByConnection = {
+				...this.state.explainTabsByConnection,
+				[connectionId]: currentTabs.filter((t) => t.id !== explainTabId)
+			};
+
+			// Switch back to query view
+			this.setActiveView('query');
+			toast.error(`Explain failed: ${error}`);
+		}
+	}
+
+	/**
+	 * Execute EXPLAIN or EXPLAIN ANALYZE with parameter substitution.
+	 * Substitutes {{param}} placeholders with values before execution.
+	 */
+	async executeWithParams(
+		tabId: string,
+		parameterValues: ParameterValue[],
+		analyze: boolean = false,
+		cursorOffset?: number
+	): Promise<void> {
+		if (!this.state.activeConnectionId || !this.state.activeConnection) return;
+
+		const connectionId = this.state.activeConnectionId;
+		const tabs = this.state.queryTabsByConnection[connectionId] ?? [];
+		const tab = tabs.find((t) => t.id === tabId);
+		if (!tab || !tab.query.trim()) return;
+
+		// Get the statement to explain based on cursor position
+		const dbType = this.state.activeConnection.type;
+		let queryToExplain = tab.query;
+
+		if (cursorOffset !== undefined) {
+			const statement = getStatementAtOffset(tab.query, cursorOffset, dbType);
+			if (statement) {
+				queryToExplain = statement.sql;
+			}
+		}
+
+		if (!queryToExplain.trim()) return;
+
+		// Substitute parameters in the query
+		const { sql: substitutedQuery, bindValues } = substituteParameters(
+			queryToExplain,
+			parameterValues,
+			dbType
+		);
+
+		// Create a new explain tab
+		const explainTabs = this.state.explainTabsByConnection[connectionId] ?? [];
+		const explainTabId = `explain-${Date.now()}`;
+		const queryPreview = queryToExplain.substring(0, 30).replace(/\s+/g, ' ').trim();
+		const newExplainTab: ExplainTab = $state({
+			id: explainTabId,
+			name: analyze ? `Analyze: ${queryPreview}...` : `Explain: ${queryPreview}...`,
+			sourceQuery: queryToExplain, // Keep original with {{}} for display
+			result: undefined,
+			isExecuting: true
+		});
+
+		this.state.explainTabsByConnection = {
+			...this.state.explainTabsByConnection,
+			[connectionId]: [...explainTabs, newExplainTab]
+		};
+
+		this.tabOrdering.add(explainTabId);
+
+		// Set as active and switch view
+		this.state.activeExplainTabIdByConnection = {
+			...this.state.activeExplainTabIdByConnection,
+			[connectionId]: explainTabId
+		};
+		this.setActiveView('explain');
+		this.schedulePersistence(connectionId);
+
+		try {
+			const adapter = getAdapter(this.state.activeConnection.type);
+			const explainQuery = adapter.getExplainQuery(substitutedQuery, analyze);
+			const providerConnectionId = this.state.activeConnection.providerConnectionId;
+
+			if (!providerConnectionId) {
+				throw new Error('No connection established');
+			}
+
+			const provider = await getProvider();
+
+			// For SQLite with analyze=true, we need to actually execute the query
+			// to get real row counts and timing
+			let actualRowCount: number | undefined;
+			let executionTime: number | undefined;
+
+			if (dbType === 'sqlite' && analyze) {
+				const startTime = performance.now();
+				const queryResult = await provider.select(providerConnectionId, substitutedQuery, bindValues);
+				executionTime = performance.now() - startTime;
+				actualRowCount = queryResult.length;
+			}
+
+			// For EXPLAIN queries, bind values are already inlined for MSSQL/DuckDB,
+			// and for PostgreSQL/SQLite we need to pass them
+			const useBindValues = dbType !== 'mssql' && dbType !== 'duckdb';
+			const result = await provider.select(
+				providerConnectionId,
+				explainQuery,
+				useBindValues ? bindValues : undefined
+			);
 
 			// Use adapter to parse the results into common format
 			const parsedNode = adapter.parseExplainResult(result, analyze);


### PR DESCRIPTION
## Summary
- Shows the parameter input dialog when running Explain or Explain Analyze on queries with `{{param}}` placeholders
- Adds `executeWithParams` method to `ExplainTabManager` for parameter substitution
- Reuses existing parameter dialog infrastructure from regular query execution

## Test plan
- [ ] Open a query with `{{param}}` placeholders (e.g., `SELECT * FROM users WHERE id = {{user_id}}`)
- [ ] Click Explain or Explain Analyze
- [ ] Verify the parameter dialog appears
- [ ] Enter values and confirm the explain plan is generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)