### PR TITLE
🎁 add: text-ellipsis on Card.Title to prevent db name overflow

### DIFF
--- a/src/lib/components/empty-states/connection-card.svelte
+++ b/src/lib/components/empty-states/connection-card.svelte
@@ -116,7 +116,9 @@
 							: m.empty_states_connection_card_disconnected()}
 					></span>
 					<DatabaseIcon class="size-4 text-muted-foreground" />
-					<Card.Title class="text-sm font-medium truncate flex-1">{connection.name}</Card.Title>
+					<Card.Title class="text-sm font-medium truncate line-clamp-1 text-ellipsis flex-1">
+						{connection.name}
+					</Card.Title>
 				</div>
 			</Card.Header>
 			<Card.Content class="pt-0 space-y-2">


### PR DESCRIPTION
## Description

Fixes a tiny visual glitch on the DB connection's name by adding an ellipsis.

## Type of change

Please select the relevant option.

-   [x] Bug fix
-   [ ] New feature
-   [ ] Chores
-   [ ] Breaking change
-   [ ] Documentation update

## Checklist:

-   [x] I did a self review of my code
-   [x] I tested my fixes/additions locally or on a dev server
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Screenshots (if applicable)

### Before
<img width="1041" height="693" alt="image" src="https://github.com/user-attachments/assets/a31503e8-1fee-4420-a864-3ac70a6025f9" />

### After
<img width="1041" height="693" alt="image" src="https://github.com/user-attachments/assets/3e404a6e-64d5-4d51-aabf-347a07fb07aa" />


## Additional context

Wanted to do a tiny bit for the project since a nice & performant OSS DB client is something I wanted for a long time :) 
