### PR TITLE
Prevent deletion of demo connection in demo mode

### DIFF
--- a/src/lib/components/sidebar-left.svelte
+++ b/src/lib/components/sidebar-left.svelte
@@ -242,14 +242,16 @@
 											<TagIcon class="size-4 me-2" />
 											{m.sidebar_connection_labels()}
 										</ContextMenu.Item>
-										<ContextMenu.Separator />
-										<ContextMenu.Item
-											class="text-destructive focus:text-destructive"
-											onclick={() => confirmRemoveConnection(connection.id, connection.name)}
-										>
-											<Trash2Icon class="size-4 me-2" />
-											{m.sidebar_connection_delete()}
-										</ContextMenu.Item>
+										{#if !(isDemo() && connection.id === "demo-connection")}
+											<ContextMenu.Separator />
+											<ContextMenu.Item
+												class="text-destructive focus:text-destructive"
+												onclick={() => confirmRemoveConnection(connection.id, connection.name)}
+											>
+												<Trash2Icon class="size-4 me-2" />
+												{m.sidebar_connection_delete()}
+											</ContextMenu.Item>
+										{/if}
 									</ContextMenu.Content>
 								</ContextMenu.Root>
 							{/each}

--- a/src/lib/hooks/database/connection-manager.svelte.ts
+++ b/src/lib/hooks/database/connection-manager.svelte.ts
@@ -9,7 +9,7 @@ import { getAdapter, type DatabaseAdapter } from "$lib/db";
 import { createSshTunnel, closeSshTunnel } from "$lib/services/ssh-tunnel";
 import { mssqlConnect, mssqlDisconnect, mssqlQuery } from "$lib/services/mssql";
 import { getProvider, type DatabaseProvider } from "$lib/providers";
-import { isTauri } from "$lib/utils/environment";
+import { isTauri, isDemo } from "$lib/utils/environment";
 import { getKeyringService } from "$lib/services/keyring";
 
 type ConnectionInput = Omit<DatabaseConnection, "id" | "projectId" | "labelIds"> & {
@@ -578,6 +578,11 @@ export class ConnectionManager {
    * Remove a connection and all its state.
    */
   remove(id: string): void {
+    // Prevent deletion of demo connection in demo mode
+    if (isDemo() && id === "demo-connection") {
+      return;
+    }
+
     const connection = this.state.connections.find((c) => c.id === id);
 
     // Close provider connection if exists


### PR DESCRIPTION
## Summary
- Hide the delete option from the context menu for the demo connection when in demo mode
- Add a guard in the connection manager to prevent programmatic deletion of the demo connection

## Test plan
- [ ] Open the demo at seaquel.app/demo
- [ ] Right-click the demo connection and verify the delete option is not visible
- [ ] Verify other connections (if any) still show the delete option

🤖 Generated with [Claude Code](https://claude.com/claude-code)