### PR TITLE
Fix ERD tab showing wrong database when switching tabs

### DIFF
--- a/src/lib/hooks/database/erd-tabs.svelte.ts
+++ b/src/lib/hooks/database/erd-tabs.svelte.ts
@@ -39,7 +39,8 @@ export class ErdTabManager {
 		const erdTabId = `erd-${Date.now()}`;
 		const newErdTab: ErdTab = {
 			id: erdTabId,
-			name: `ERD: ${this.state.activeConnection.name}`
+			name: `ERD: ${this.state.activeConnection.name}`,
+			connectionId: this.state.activeConnectionId
 		};
 
 		this.state.erdTabsByProject = {

--- a/src/lib/hooks/database/persistence-manager.svelte.ts
+++ b/src/lib/hooks/database/persistence-manager.svelte.ts
@@ -126,6 +126,7 @@ export class PersistenceManager {
     return tabs.map((tab) => ({
       id: tab.id,
       name: tab.name,
+      connectionId: tab.connectionId,
     }));
   }
 

--- a/src/lib/hooks/database/project-manager.svelte.ts
+++ b/src/lib/hooks/database/project-manager.svelte.ts
@@ -312,11 +312,14 @@ export class ProjectManager {
       isExecuting: false,
     }));
 
-    // Restore ERD tabs
-    this.state.erdTabsByProject[projectId] = persistedState.erdTabs.map((t) => ({
-      id: t.id,
-      name: t.name,
-    }));
+    // Restore ERD tabs (connectionId may be missing in old persisted data)
+    this.state.erdTabsByProject[projectId] = persistedState.erdTabs
+      .filter((t) => t.connectionId)
+      .map((t) => ({
+        id: t.id,
+        name: t.name,
+        connectionId: t.connectionId!,
+      }));
 
     // Restore tab order and active IDs
     this.state.tabOrderByProject[projectId] = persistedState.tabOrder;

--- a/src/lib/types/erd.ts
+++ b/src/lib/types/erd.ts
@@ -11,4 +11,6 @@ export interface ErdTab {
 	id: string;
 	/** Tab display name */
 	name: string;
+	/** Connection ID this ERD tab belongs to */
+	connectionId: string;
 }

--- a/src/lib/types/persisted.ts
+++ b/src/lib/types/persisted.ts
@@ -54,6 +54,8 @@ export interface PersistedErdTab {
 	id: string;
 	/** Tab display name */
 	name: string;
+	/** Connection ID this ERD tab belongs to */
+	connectionId?: string;
 }
 
 /**

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -81,6 +81,10 @@
     };
 
     const handleErdTabClick = (tabId: string) => {
+        const erdTab = db.state.erdTabs.find(t => t.id === tabId);
+        if (erdTab?.connectionId) {
+            db.connections.setActive(erdTab.connectionId);
+        }
         db.erdTabs.setActive(tabId);
         db.ui.setActiveView("erd");
     };


### PR DESCRIPTION
## Summary
- ERD tabs now store the `connectionId` they were created with
- Clicking an ERD tab switches to that tab's connection before displaying
- Fixes bug where switching ERD tabs showed the wrong database schema

## Test plan
- [ ] Connect to DB 1, open ERD tab
- [ ] Connect to DB 2, open ERD tab
- [ ] Click DB 1's ERD tab - should show DB 1's schema
- [ ] Click DB 2's ERD tab - should show DB 2's schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)