### PR TITLE
Add DuckDB connection support in desktop app

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -45,12 +45,24 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "const-random",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -165,6 +177,164 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "arrow-select"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
+]
 
 [[package]]
 name = "as-slice"
@@ -376,6 +546,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +595,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +649,28 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -538,6 +765,12 @@ dependencies = [
  "serde",
  "toml 0.9.10+spec-1.1.0",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
@@ -657,6 +890,17 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "comfy-table"
+version = "7.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
+dependencies = [
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1223,6 +1467,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7eeb487dde618b9f6ab26a451775ad5fac3fabe1ca2b64cbbe90b105f264ccd"
+dependencies = [
+ "arrow",
+ "cast",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys",
+ "num-integer",
+ "rust_decimal",
+ "strum 0.27.2",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,6 +1704,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1554,7 +1828,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "num_cpus",
  "parking_lot",
  "seize",
@@ -1622,6 +1896,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -2087,6 +2367,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -2095,6 +2376,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2699,6 +2983,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,6 +3076,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
  "pkg-config",
+]
+
+[[package]]
+name = "libduckdb-sys"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8c60c2d269e63ae5197e4fe9075efffed35dfda0095a5ac8b41f3c765b18456"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+ "zip 6.0.0",
 ]
 
 [[package]]
@@ -2783,6 +3141,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3056,6 +3423,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3461,15 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4067,6 +4457,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4168,6 +4578,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4445,6 +4861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,6 +4877,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -4537,6 +4963,35 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4703,6 +5158,22 @@ dependencies = [
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35affe401787a9bd846712274d97654355d21b2a2c092a3139aabe31e9022282"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4876,6 +5347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "seaquel"
 version = "2026.2.0"
 dependencies = [
@@ -4884,6 +5361,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "dirs 5.0.1",
+ "duckdb",
  "image",
  "russh",
  "russh-keys",
@@ -4903,6 +5381,7 @@ dependencies = [
  "tiberius",
  "tokio",
  "tokio-util",
+ "uuid",
 ]
 
 [[package]]
@@ -5211,6 +5690,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5611,6 +6096,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5741,6 +6266,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -6050,7 +6581,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -6682,6 +7213,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "universal-hash"
@@ -7786,6 +8323,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x11"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7969,10 +8515,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+
+[[package]]
 name = "zmij"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,8 @@ tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-sql = { version = "2", features = ["postgres", "sqlite"] }
+duckdb = { version = "1.1", features = ["bundled"] }
+uuid = { version = "1", features = ["v4"] }
 tauri-plugin-store = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"

--- a/src-tauri/src/duckdb_commands.rs
+++ b/src-tauri/src/duckdb_commands.rs
@@ -1,0 +1,178 @@
+use duckdb::{Connection, types::ValueRef};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use tauri::State;
+use uuid::Uuid;
+
+/// State for managing DuckDB connections
+pub struct DuckDBState {
+    connections: Mutex<HashMap<String, Connection>>,
+}
+
+impl Default for DuckDBState {
+    fn default() -> Self {
+        Self {
+            connections: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct DuckDBConnectResult {
+    connection_id: String,
+}
+
+#[derive(Serialize)]
+pub struct DuckDBQueryResult {
+    columns: Vec<String>,
+    rows: Vec<Vec<serde_json::Value>>,
+}
+
+#[derive(Serialize)]
+pub struct DuckDBExecuteResult {
+    rows_affected: usize,
+}
+
+/// Connect to a DuckDB database
+#[tauri::command]
+pub fn duckdb_connect(
+    state: State<DuckDBState>,
+    path: String,
+) -> Result<DuckDBConnectResult, String> {
+    let conn = if path == ":memory:" || path.is_empty() {
+        Connection::open_in_memory()
+    } else {
+        Connection::open(&path)
+    }
+    .map_err(|e| e.to_string())?;
+
+    let connection_id = format!("duckdb-{}", Uuid::new_v4());
+    state
+        .connections
+        .lock()
+        .map_err(|e| e.to_string())?
+        .insert(connection_id.clone(), conn);
+
+    Ok(DuckDBConnectResult { connection_id })
+}
+
+/// Disconnect from a DuckDB database
+#[tauri::command]
+pub fn duckdb_disconnect(
+    state: State<DuckDBState>,
+    connection_id: String,
+) -> Result<(), String> {
+    state
+        .connections
+        .lock()
+        .map_err(|e| e.to_string())?
+        .remove(&connection_id);
+    Ok(())
+}
+
+/// Execute a SELECT query and return results
+#[tauri::command]
+pub fn duckdb_query(
+    state: State<DuckDBState>,
+    connection_id: String,
+    sql: String,
+) -> Result<DuckDBQueryResult, String> {
+    let connections = state.connections.lock().map_err(|e| e.to_string())?;
+    let conn = connections
+        .get(&connection_id)
+        .ok_or("Connection not found")?;
+
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+
+    // Execute query first - column metadata is only available after execution
+    let mut result_rows = stmt.query([]).map_err(|e| e.to_string())?;
+
+    // Get column info from the executed statement
+    let column_count = result_rows.as_ref().map(|s| s.column_count()).unwrap_or(0);
+    let columns: Vec<String> = (0..column_count)
+        .map(|i| {
+            result_rows
+                .as_ref()
+                .and_then(|s| s.column_name(i).ok())
+                .map(|s| s.to_string())
+                .unwrap_or_default()
+        })
+        .collect();
+
+    let mut rows: Vec<Vec<serde_json::Value>> = Vec::new();
+
+    while let Some(row) = result_rows.next().map_err(|e| e.to_string())? {
+        let mut values: Vec<serde_json::Value> = Vec::new();
+        for i in 0..column_count {
+            let value = row.get_ref(i).map_err(|e| e.to_string())?;
+            let json_value = convert_value_to_json(value);
+            values.push(json_value);
+        }
+        rows.push(values);
+    }
+
+    Ok(DuckDBQueryResult { columns, rows })
+}
+
+/// Execute a non-SELECT SQL statement (INSERT, UPDATE, DELETE, CREATE, etc.)
+#[tauri::command]
+pub fn duckdb_execute(
+    state: State<DuckDBState>,
+    connection_id: String,
+    sql: String,
+) -> Result<DuckDBExecuteResult, String> {
+    let connections = state.connections.lock().map_err(|e| e.to_string())?;
+    let conn = connections
+        .get(&connection_id)
+        .ok_or("Connection not found")?;
+
+    let rows_affected = conn.execute(&sql, []).map_err(|e| e.to_string())?;
+
+    Ok(DuckDBExecuteResult { rows_affected })
+}
+
+/// Test a DuckDB connection by opening and immediately closing it
+#[tauri::command]
+pub fn duckdb_test(path: String) -> Result<(), String> {
+    let _conn = if path == ":memory:" || path.is_empty() {
+        Connection::open_in_memory()
+    } else {
+        Connection::open(&path)
+    }
+    .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+/// Convert a DuckDB ValueRef to a serde_json::Value
+fn convert_value_to_json(value: ValueRef) -> serde_json::Value {
+    match value {
+        ValueRef::Null => serde_json::Value::Null,
+        ValueRef::Boolean(b) => serde_json::json!(b),
+        ValueRef::TinyInt(i) => serde_json::json!(i),
+        ValueRef::SmallInt(i) => serde_json::json!(i),
+        ValueRef::Int(i) => serde_json::json!(i),
+        ValueRef::BigInt(i) => serde_json::json!(i),
+        ValueRef::HugeInt(i) => serde_json::json!(i.to_string()),
+        ValueRef::UTinyInt(i) => serde_json::json!(i),
+        ValueRef::USmallInt(i) => serde_json::json!(i),
+        ValueRef::UInt(i) => serde_json::json!(i),
+        ValueRef::UBigInt(i) => serde_json::json!(i),
+        ValueRef::Float(f) => serde_json::json!(f),
+        ValueRef::Double(f) => serde_json::json!(f),
+        ValueRef::Decimal(d) => serde_json::json!(d.to_string()),
+        ValueRef::Text(s) => serde_json::json!(String::from_utf8_lossy(s)),
+        ValueRef::Blob(b) => serde_json::json!(base64::Engine::encode(&base64::engine::general_purpose::STANDARD, b)),
+        ValueRef::Date32(d) => serde_json::json!(d),
+        ValueRef::Time64(..) => serde_json::json!(format!("{:?}", value)),
+        ValueRef::Timestamp(..) => serde_json::json!(format!("{:?}", value)),
+        ValueRef::Interval { .. } => serde_json::json!(format!("{:?}", value)),
+        ValueRef::List(..) => serde_json::json!(format!("{:?}", value)),
+        ValueRef::Enum(..) => serde_json::json!(format!("{:?}", value)),
+        ValueRef::Struct(..) => serde_json::json!(format!("{:?}", value)),
+        ValueRef::Map(..) => serde_json::json!(format!("{:?}", value)),
+        ValueRef::Array(..) => serde_json::json!(format!("{:?}", value)),
+        ValueRef::Union(..) => serde_json::json!(format!("{:?}", value)),
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,9 +6,11 @@ use tauri::menu::{AboutMetadata, Menu, MenuItemBuilder, PredefinedMenuItem, Subm
 use tauri::{Emitter, Manager};
 use tauri_plugin_updater::UpdaterExt;
 
+mod duckdb_commands;
 mod mssql;
 mod ssh_tunnel;
 
+use duckdb_commands::DuckDBState;
 use mssql::MssqlConnectionManager;
 use ssh_tunnel::TunnelManager;
 
@@ -183,6 +185,7 @@ pub fn run() {
         .plugin(tauri_plugin_os::init())
         .manage(TunnelManager::new())
         .manage(MssqlConnectionManager::new())
+        .manage(DuckDBState::default())
         .manage(PendingUpdate { bytes: Mutex::new(None) })
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
@@ -205,6 +208,11 @@ pub fn run() {
             mssql::mssql_disconnect,
             mssql::mssql_query,
             mssql::mssql_execute,
+            duckdb_commands::duckdb_connect,
+            duckdb_commands::duckdb_disconnect,
+            duckdb_commands::duckdb_query,
+            duckdb_commands::duckdb_execute,
+            duckdb_commands::duckdb_test,
         ])
         .setup(|app| {
             // Set up custom menu

--- a/src/lib/components/connection-wizard/database-type-card.svelte
+++ b/src/lib/components/connection-wizard/database-type-card.svelte
@@ -17,7 +17,7 @@
 		mysql: "bg-orange-500/10 text-orange-600 dark:text-orange-400",
 		mariadb: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
 		sqlite: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
-		mongodb: "bg-green-500/10 text-green-600 dark:text-green-400",
+		duckdb: "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400",
 		mssql: "bg-red-500/10 text-red-600 dark:text-red-400",
 	};
 

--- a/src/lib/config/sample-queries.ts
+++ b/src/lib/config/sample-queries.ts
@@ -111,21 +111,6 @@ LIMIT 10;`,
 			requiresTable: true,
 		},
 	],
-	mongodb: [
-		{
-			id: "mongo-list-collections",
-			name: "List all collections",
-			description: "View all collections in your database",
-			query: `db.getCollectionNames()`,
-		},
-		{
-			id: "mongo-sample-data",
-			name: "Preview collection data",
-			description: "View sample documents from a collection",
-			query: `db.your_collection.find().limit(10)`,
-			requiresTable: true,
-		},
-	],
 	mssql: [
 		{
 			id: "mssql-list-tables",
@@ -163,6 +148,27 @@ ORDER BY table_schema, table_name;`,
 FROM your_table
 LIMIT 10;`,
 			requiresTable: true,
+		},
+		{
+			id: "duckdb-describe-table",
+			name: "Describe table structure",
+			description: "View columns and types for a table",
+			query: `DESCRIBE your_table;`,
+			requiresTable: true,
+		},
+		{
+			id: "duckdb-import-csv",
+			name: "Import CSV file",
+			description: "Load data from a CSV file",
+			query: `CREATE TABLE my_data AS
+SELECT * FROM read_csv_auto('/path/to/file.csv');`,
+		},
+		{
+			id: "duckdb-import-parquet",
+			name: "Import Parquet file",
+			description: "Load data from a Parquet file",
+			query: `CREATE TABLE my_data AS
+SELECT * FROM read_parquet('/path/to/file.parquet');`,
 		},
 	],
 };

--- a/src/lib/hooks/database/connection-manager.svelte.ts
+++ b/src/lib/hooks/database/connection-manager.svelte.ts
@@ -8,7 +8,7 @@ import type { TabOrderingManager } from "./tab-ordering.svelte.js";
 import { getAdapter, type DatabaseAdapter } from "$lib/db";
 import { createSshTunnel, closeSshTunnel } from "$lib/services/ssh-tunnel";
 import { mssqlConnect, mssqlDisconnect, mssqlQuery } from "$lib/services/mssql";
-import { getProvider, type DatabaseProvider } from "$lib/providers";
+import { getProvider, getDuckDBProvider, type DatabaseProvider } from "$lib/providers";
 import { isTauri, isDemo } from "$lib/utils/environment";
 import { getKeyringService } from "$lib/services/keyring";
 
@@ -31,6 +31,7 @@ export class ConnectionManager {
   // Map connection IDs to their SSH tunnel IDs for cleanup
   private tunnelIds = new Map<string, string>();
   private provider: DatabaseProvider | null = null;
+  private duckdbProvider: DatabaseProvider | null = null;
 
   constructor(
     private state: DatabaseState,
@@ -49,6 +50,26 @@ export class ConnectionManager {
       this.provider = await getProvider();
     }
     return this.provider;
+  }
+
+  /**
+   * Get or create the DuckDB provider.
+   */
+  private async getOrCreateDuckDBProvider(): Promise<DatabaseProvider> {
+    if (!this.duckdbProvider) {
+      this.duckdbProvider = await getDuckDBProvider();
+    }
+    return this.duckdbProvider;
+  }
+
+  /**
+   * Get the appropriate provider based on database type.
+   */
+  private async getProviderForType(dbType: string): Promise<DatabaseProvider> {
+    if (dbType === "duckdb") {
+      return this.getOrCreateDuckDBProvider();
+    }
+    return this.getOrCreateProvider();
   }
 
   /**
@@ -78,7 +99,8 @@ export class ConnectionManager {
         if (!username && persisted.connectionString) {
           try {
             const connStr = persisted.connectionString.replace("postgresql://", "postgres://");
-            if (!connStr.startsWith("sqlite")) {
+            // SQLite and DuckDB use file-based connection strings, not URLs
+            if (!connStr.startsWith("sqlite") && !connStr.startsWith("duckdb")) {
               const url = new URL(connStr);
               username = url.username ? decodeURIComponent(url.username) : "";
             }
@@ -193,7 +215,7 @@ export class ConnectionManager {
       connectionId
     );
 
-    // Connect to database - MSSQL uses custom backend, others use provider
+    // Connect to database - MSSQL and DuckDB use custom backends, others use provider
     let providerConnectionId: string | undefined;
     let mssqlConnectionId: string | undefined;
 
@@ -214,8 +236,16 @@ export class ConnectionManager {
         trustCert: connection.sslMode !== "require",
       });
       mssqlConnectionId = mssqlConn.connectionId;
+    } else if (connection.type === "duckdb") {
+      // DuckDB uses dedicated provider (Tauri backend in desktop, WASM in browser)
+      const duckdbProvider = await getDuckDBProvider();
+      providerConnectionId = await duckdbProvider.connect({
+        type: connection.type,
+        connectionString: effectiveConnectionString,
+        databaseName: connection.databaseName,
+      });
     } else if (effectiveConnectionString) {
-      // Use provider for PostgreSQL, SQLite, DuckDB
+      // Use provider for PostgreSQL, SQLite
       const provider = await this.getOrCreateProvider();
       providerConnectionId = await provider.connect({
         type: connection.type,
@@ -251,7 +281,7 @@ export class ConnectionManager {
         const result = await mssqlQuery(mssqlConnectionId, adapter.getSchemaQuery());
         schemasWithTablesDbResult = result.rows;
       } else if (providerConnectionId) {
-        const provider = await this.getOrCreateProvider();
+        const provider = await this.getProviderForType(newConnection.type);
         schemasWithTablesDbResult = await provider.select(providerConnectionId, adapter.getSchemaQuery());
       } else {
         throw new Error("No connection established");
@@ -265,7 +295,7 @@ export class ConnectionManager {
         await mssqlDisconnect(mssqlConnectionId).catch(() => {});
       }
       if (providerConnectionId) {
-        const provider = await this.getOrCreateProvider();
+        const provider = await this.getProviderForType(newConnection.type);
         await provider.disconnect(providerConnectionId).catch(() => {});
       }
       throw new Error(`Failed to load database schema: ${error}`);
@@ -333,11 +363,17 @@ export class ConnectionManager {
       await mssqlDisconnect(existingConnection.mssqlConnectionId).catch(() => {});
     }
     if (existingConnection.providerConnectionId) {
-      const provider = await this.getOrCreateProvider();
-      await provider.disconnect(existingConnection.providerConnectionId).catch(() => {});
+      // Use appropriate provider for disconnect based on type
+      if (existingConnection.type === "duckdb") {
+        const duckdbProvider = await getDuckDBProvider();
+        await duckdbProvider.disconnect(existingConnection.providerConnectionId).catch(() => {});
+      } else {
+        const provider = await this.getOrCreateProvider();
+        await provider.disconnect(existingConnection.providerConnectionId).catch(() => {});
+      }
     }
 
-    // Connect to database - MSSQL uses custom backend, others use provider
+    // Connect to database - MSSQL and DuckDB use custom backends, others use provider
     let providerConnectionId: string | undefined;
     let mssqlConnectionId: string | undefined;
 
@@ -358,8 +394,16 @@ export class ConnectionManager {
         trustCert: connection.sslMode !== "require",
       });
       mssqlConnectionId = mssqlConn.connectionId;
+    } else if (connection.type === "duckdb") {
+      // DuckDB uses dedicated provider (Tauri backend in desktop, WASM in browser)
+      const duckdbProvider = await getDuckDBProvider();
+      providerConnectionId = await duckdbProvider.connect({
+        type: connection.type,
+        connectionString: effectiveConnectionString,
+        databaseName: connection.databaseName,
+      });
     } else if (effectiveConnectionString) {
-      // Use provider for PostgreSQL, SQLite, DuckDB
+      // Use provider for PostgreSQL, SQLite
       const provider = await this.getOrCreateProvider();
       providerConnectionId = await provider.connect({
         type: connection.type,
@@ -396,7 +440,7 @@ export class ConnectionManager {
         const result = await mssqlQuery(mssqlConnectionId, adapter.getSchemaQuery());
         schemasWithTablesDbResult = result.rows;
       } else if (providerConnectionId) {
-        const provider = await this.getOrCreateProvider();
+        const provider = await this.getProviderForType(existingConnection.type);
         schemasWithTablesDbResult = await provider.select(providerConnectionId, adapter.getSchemaQuery());
       } else {
         throw new Error("No connection established");
@@ -411,7 +455,7 @@ export class ConnectionManager {
         await mssqlDisconnect(mssqlConnectionId).catch(() => {});
       }
       if (providerConnectionId) {
-        const provider = await this.getOrCreateProvider();
+        const provider = await this.getProviderForType(existingConnection.type);
         await provider.disconnect(providerConnectionId).catch(() => {});
       }
       throw new Error(`Failed to load database schema: ${error}`);
@@ -532,7 +576,7 @@ export class ConnectionManager {
     let providerTestConnectionId: string | undefined;
 
     try {
-      // MSSQL uses custom backend, others use provider
+      // MSSQL and DuckDB use custom backends, others use provider
       if (connection.type === "mssql") {
         if (!isTauri()) {
           throw new Error("MSSQL connections are only available in the desktop app");
@@ -551,8 +595,18 @@ export class ConnectionManager {
         mssqlTestConnectionId = mssqlConn.connectionId;
         // Close the test connection immediately
         await mssqlDisconnect(mssqlTestConnectionId);
+      } else if (connection.type === "duckdb") {
+        // DuckDB uses dedicated provider
+        const duckdbProvider = await getDuckDBProvider();
+        providerTestConnectionId = await duckdbProvider.connect({
+          type: connection.type,
+          connectionString: effectiveConnectionString,
+          databaseName: connection.databaseName,
+        });
+        // Close the test connection immediately
+        await duckdbProvider.disconnect(providerTestConnectionId);
       } else if (effectiveConnectionString) {
-        // Use provider for PostgreSQL, SQLite, DuckDB
+        // Use provider for PostgreSQL, SQLite
         const provider = await this.getOrCreateProvider();
         providerTestConnectionId = await provider.connect({
           type: connection.type,
@@ -587,9 +641,16 @@ export class ConnectionManager {
 
     // Close provider connection if exists
     if (connection?.providerConnectionId) {
-      this.getOrCreateProvider().then(provider => {
-        provider.disconnect(connection.providerConnectionId!).catch(console.error);
-      });
+      // Use appropriate provider for disconnect based on type
+      if (connection.type === "duckdb") {
+        getDuckDBProvider().then(duckdbProvider => {
+          duckdbProvider.disconnect(connection.providerConnectionId!).catch(console.error);
+        });
+      } else {
+        this.getOrCreateProvider().then(provider => {
+          provider.disconnect(connection.providerConnectionId!).catch(console.error);
+        });
+      }
     }
 
     // Close MSSQL connection if exists
@@ -679,7 +740,7 @@ export class ConnectionManager {
 
     // Load schema
     const adapter = getAdapter("duckdb");
-    const provider = await this.getOrCreateProvider();
+    const provider = await this.getOrCreateDuckDBProvider();
     const schemasWithTablesDbResult = await provider.select(providerConnectionId, adapter.getSchemaQuery());
     const schemasWithTables = adapter.parseSchemaResult(schemasWithTablesDbResult as unknown[]);
 
@@ -712,8 +773,8 @@ export class ConnectionManager {
       return false;
     }
 
-    // SQLite doesn't require passwords, always auto-reconnect
-    if (connection.type === "sqlite") {
+    // SQLite and DuckDB don't require passwords, always auto-reconnect
+    if (connection.type === "sqlite" || connection.type === "duckdb") {
       try {
         await this.reconnect(connectionId, {
           name: connection.name,
@@ -728,7 +789,7 @@ export class ConnectionManager {
         });
         return true;
       } catch (error) {
-        console.warn("Auto-reconnect failed for SQLite:", error);
+        console.warn(`Auto-reconnect failed for ${connection.type}:`, error);
         return false;
       }
     }
@@ -809,9 +870,16 @@ export class ConnectionManager {
 
       // Disconnect provider connection if connected
       if (connection.providerConnectionId) {
-        this.getOrCreateProvider().then(provider => {
-          provider.disconnect(connection.providerConnectionId!).catch(console.error);
-        });
+        // Use appropriate provider for disconnect based on type
+        if (connection.type === "duckdb") {
+          getDuckDBProvider().then(duckdbProvider => {
+            duckdbProvider.disconnect(connection.providerConnectionId!).catch(console.error);
+          });
+        } else {
+          this.getOrCreateProvider().then(provider => {
+            provider.disconnect(connection.providerConnectionId!).catch(console.error);
+          });
+        }
         connection.providerConnectionId = undefined;
       }
 

--- a/src/lib/providers/duckdb-tauri-provider.ts
+++ b/src/lib/providers/duckdb-tauri-provider.ts
@@ -1,0 +1,116 @@
+/**
+ * DuckDB provider for Tauri desktop app.
+ * Uses custom Rust backend with DuckDB crate.
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+import type { DatabaseProvider, ConnectionConfig, ExecuteResult } from './types';
+
+interface DuckDBConnectResult {
+	connection_id: string;
+}
+
+interface DuckDBQueryResult {
+	columns: string[];
+	rows: unknown[][];
+}
+
+interface DuckDBExecuteResultRust {
+	rows_affected: number;
+}
+
+/**
+ * DuckDB provider implementation for Tauri (desktop).
+ * Calls Rust backend commands for DuckDB operations.
+ */
+export class DuckDBTauriProvider implements DatabaseProvider {
+	readonly id = 'duckdb-tauri';
+
+	/**
+	 * Check if Tauri API is available.
+	 */
+	isAvailable(): boolean {
+		return typeof window !== 'undefined' && '__TAURI__' in window;
+	}
+
+	/**
+	 * Connect to a DuckDB database.
+	 * @param config Connection configuration with databaseName as file path or ":memory:"
+	 */
+	async connect(config: ConnectionConfig): Promise<string> {
+		// Extract path from connection string or use databaseName
+		let path = config.databaseName || ':memory:';
+
+		if (config.connectionString) {
+			path = config.connectionString
+				.replace(/^duckdb:\/\//, '')
+				.replace(/^duckdb:/, '') || ':memory:';
+		}
+
+		const result = await invoke<DuckDBConnectResult>('duckdb_connect', { path });
+		return result.connection_id;
+	}
+
+	/**
+	 * Disconnect from a DuckDB database.
+	 */
+	async disconnect(connectionId: string): Promise<void> {
+		await invoke('duckdb_disconnect', { connectionId });
+	}
+
+	/**
+	 * Execute a SELECT query and return results.
+	 */
+	async select<T = Record<string, unknown>>(
+		connectionId: string,
+		sql: string,
+		_params?: unknown[]
+	): Promise<T[]> {
+		const result = await invoke<DuckDBQueryResult>('duckdb_query', {
+			connectionId,
+			sql,
+		});
+
+		// Convert array rows to objects using column names
+		return result.rows.map((row) => {
+			const obj: Record<string, unknown> = {};
+			result.columns.forEach((col, i) => {
+				obj[col] = row[i];
+			});
+			return obj as T;
+		});
+	}
+
+	/**
+	 * Execute a write query (INSERT, UPDATE, DELETE, CREATE, etc.).
+	 */
+	async execute(
+		connectionId: string,
+		sql: string,
+		_params?: unknown[]
+	): Promise<ExecuteResult> {
+		const result = await invoke<DuckDBExecuteResultRust>('duckdb_execute', {
+			connectionId,
+			sql,
+		});
+
+		return {
+			rowsAffected: result.rows_affected,
+		};
+	}
+
+	/**
+	 * Test a DuckDB connection by opening and immediately closing it.
+	 */
+	async test(config: ConnectionConfig): Promise<void> {
+		let path = config.databaseName || ':memory:';
+
+		if (config.connectionString) {
+			path = config.connectionString
+				.replace(/^duckdb:\/\//, '')
+				.replace(/^duckdb:/, '') || ':memory:';
+		}
+
+		await invoke('duckdb_test', { path });
+	}
+}

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -9,6 +9,7 @@ import { isTauri } from '$lib/utils/environment';
 export type { DatabaseProvider, ConnectionConfig, ExecuteResult } from './types';
 
 let provider: DatabaseProvider | null = null;
+let duckdbProvider: DatabaseProvider | null = null;
 
 /**
  * Get the database provider for the current environment.
@@ -29,6 +30,24 @@ export async function getProvider(): Promise<DatabaseProvider> {
 }
 
 /**
+ * Get the DuckDB provider for the current environment.
+ * Returns DuckDBTauriProvider in desktop app, DuckDBProvider (WASM) in browser.
+ */
+export async function getDuckDBProvider(): Promise<DatabaseProvider> {
+	if (duckdbProvider) return duckdbProvider;
+
+	if (isTauri()) {
+		const { DuckDBTauriProvider } = await import('./duckdb-tauri-provider');
+		duckdbProvider = new DuckDBTauriProvider();
+	} else {
+		const { DuckDBProvider } = await import('./duckdb-provider');
+		duckdbProvider = new DuckDBProvider();
+	}
+
+	return duckdbProvider;
+}
+
+/**
  * Check if we're in demo mode (browser, not Tauri).
  */
 export function isDemo(): boolean {
@@ -41,4 +60,5 @@ export function isDemo(): boolean {
  */
 export function resetProvider(): void {
 	provider = null;
+	duckdbProvider = null;
 }

--- a/src/lib/services/dbeaver-import.ts
+++ b/src/lib/services/dbeaver-import.ts
@@ -15,9 +15,9 @@ const PROVIDER_MAP: Record<string, DatabaseType> = {
 	mysql: "mysql",
 	mariadb: "mariadb",
 	sqlite: "sqlite",
-	mongodb: "mongodb",
 	mssql: "mssql",
 	sqlserver: "mssql",
+	duckdb: "duckdb",
 };
 
 /**
@@ -28,7 +28,6 @@ const DEFAULT_PORTS: Record<DatabaseType, number> = {
 	mysql: 3306,
 	mariadb: 3306,
 	sqlite: 0,
-	mongodb: 27017,
 	mssql: 1433,
 	duckdb: 0,
 };

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -8,7 +8,7 @@ import type Database from '@tauri-apps/plugin-sql';
 /**
  * Supported database engine types.
  */
-export type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mongodb' | 'mariadb' | 'mssql' | 'duckdb';
+export type DatabaseType = 'postgres' | 'mysql' | 'sqlite' | 'mariadb' | 'mssql' | 'duckdb';
 
 /**
  * SSH tunnel authentication methods.


### PR DESCRIPTION
## Summary
- Replace MongoDB (which had no backend implementation) with DuckDB in the connection wizard
- Add full DuckDB support for desktop using a custom Rust backend with the native `duckdb` crate
- Support both file-based (.duckdb) and in-memory DuckDB databases

## Changes
- **Rust Backend**: Add DuckDB Tauri commands (`duckdb_connect`, `duckdb_disconnect`, `duckdb_query`, `duckdb_execute`, `duckdb_test`) using the `duckdb` crate
- **Frontend Provider**: Add `DuckDBTauriProvider` for desktop that calls Rust backend, uses existing WASM provider in browser demo
- **Connection Wizard**: Update UI to show DuckDB option with file browser and in-memory toggle
- **Provider Routing**: Route all DuckDB operations through the correct provider (fixes "invalid connection url" and "connection not found" errors)
- **Type Cleanup**: Remove `mongodb` from `DatabaseType` union

## Technical Notes
- `tauri-plugin-sql` does not support DuckDB (only postgres, sqlite, mysql), hence the custom Rust backend
- Column metadata in DuckDB Rust crate is only available after query execution (fixed panic issue)

## Test plan
- [ ] Create DuckDB in-memory connection in desktop app
- [ ] Create DuckDB file-based connection in desktop app
- [ ] Run queries, browse schema, view statistics
- [ ] Verify demo mode still works with DuckDB WASM

🤖 Generated with [Claude Code](https://claude.com/claude-code)