### PR TITLE
Add query visualizer feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "layerchart": "^2.0.0-next.44",
         "monaco-editor": "^0.55.1",
         "monaco-sql-languages": "^0.15.1",
+        "node-sql-parser": "^5.4.0",
         "sql-formatter": "^15.6.12",
         "svelte-dnd-action": "^0.9.69",
         "tauri-plugin-keyring-api": "^0.1.1"
@@ -1962,6 +1963,12 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pegjs": {
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
+      "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2165,6 +2172,15 @@
       },
       "engines": {
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/bindings": {
@@ -3890,6 +3906,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-sql-parser": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/node-sql-parser/-/node-sql-parser-5.4.0.tgz",
+      "integrity": "sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/pegjs": "^0.10.0",
+        "big-integer": "^1.6.48"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/once": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "layerchart": "^2.0.0-next.44",
     "monaco-editor": "^0.55.1",
     "monaco-sql-languages": "^0.15.1",
+    "node-sql-parser": "^5.4.0",
     "sql-formatter": "^15.6.12",
     "svelte-dnd-action": "^0.9.69",
     "tauri-plugin-keyring-api": "^0.1.1"

--- a/src/lib/components/command-palette.svelte
+++ b/src/lib/components/command-palette.svelte
@@ -80,7 +80,7 @@
 		runAndClose(() => db.ui.toggleAI());
 	}
 
-	function goToTab(tabId: string, type: "query" | "schema" | "explain" | "erd" | "statistics" | "canvas") {
+	function goToTab(tabId: string, type: "query" | "schema" | "explain" | "erd" | "statistics" | "canvas" | "visualize") {
 		runAndClose(() => {
 			switch (type) {
 				case "query":
@@ -106,6 +106,10 @@
 				case "canvas":
 					db.canvasTabs.setActive(tabId);
 					db.ui.setActiveView("canvas");
+					break;
+				case "visualize":
+					db.visualizeTabs.setActive(tabId);
+					db.ui.setActiveView("visualize");
 					break;
 			}
 		});
@@ -283,6 +287,8 @@
 				return BarChart3;
 			case "canvas":
 				return LayoutGrid;
+			case "visualize":
+				return GitBranch;
 			default:
 				return FileText;
 		}

--- a/src/lib/components/query-editor.svelte
+++ b/src/lib/components/query-editor.svelte
@@ -268,6 +268,12 @@
 		}
 	};
 
+	const handleVisualize = () => {
+		if (!db.state.activeQueryTabId || !db.state.activeQueryTab) return;
+		const cursorOffset = monacoRef?.getCursorOffset() ?? 0;
+		db.visualizeTabs.visualize(db.state.activeQueryTabId, cursorOffset);
+	};
+
 	const handleSave = () => {
 		if (!db.state.activeQueryTab?.query.trim()) return;
 		showSaveDialog = true;
@@ -383,6 +389,7 @@
 			onExecute={handleExecute}
 			onExecuteCurrent={handleExecuteCurrent}
 			onExplain={handleExplain}
+			onVisualize={handleVisualize}
 			onFormat={handleFormat}
 			onSave={handleSave}
 		/>

--- a/src/lib/components/query-editor/query-toolbar.svelte
+++ b/src/lib/components/query-editor/query-toolbar.svelte
@@ -17,7 +17,8 @@
 		SearchIcon,
 		ActivityIcon,
 		DatabaseIcon,
-		CheckIcon
+		CheckIcon,
+		NetworkIcon
 	} from "@lucide/svelte";
 	import { m } from "$lib/paraglide/messages.js";
 	import type { StatementResult } from "$lib/types";
@@ -30,6 +31,7 @@
 		onExecute: () => void;
 		onExecuteCurrent: () => void;
 		onExplain: (analyze: boolean) => void;
+		onVisualize: () => void;
 		onFormat: () => void;
 		onSave: () => void;
 	};
@@ -42,6 +44,7 @@
 		onExecute,
 		onExecuteCurrent,
 		onExplain,
+		onVisualize,
 		onFormat,
 		onSave
 	}: Props = $props();
@@ -242,6 +245,11 @@
 					<DropdownMenu.Item onclick={() => onExplain(true)}>
 						<ActivityIcon class="size-4 me-2" />
 						{m.query_explain_analyze()}
+					</DropdownMenu.Item>
+					<DropdownMenu.Separator />
+					<DropdownMenu.Item onclick={onVisualize}>
+						<NetworkIcon class="size-4 me-2" />
+						Visualize Query
 					</DropdownMenu.Item>
 				</DropdownMenu.Content>
 			</DropdownMenu.Root>

--- a/src/lib/components/query-visual-viewer.svelte
+++ b/src/lib/components/query-visual-viewer.svelte
@@ -1,0 +1,315 @@
+<script lang="ts">
+	import { useDatabase } from "$lib/hooks/database.svelte.js";
+	import { SvelteFlow, Background, Controls, MiniMap } from "@xyflow/svelte";
+	import "@xyflow/svelte/dist/style.css";
+	import { toPng } from "html-to-image";
+	import { toast } from "svelte-sonner";
+	import { save } from "@tauri-apps/plugin-dialog";
+	import { writeFile } from "@tauri-apps/plugin-fs";
+	import { Button } from "$lib/components/ui/button";
+	import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
+	import * as Popover from "$lib/components/ui/popover";
+	import { Label } from "$lib/components/ui/label";
+	import { Input } from "$lib/components/ui/input";
+	import {
+		NetworkIcon,
+		DownloadIcon,
+		ImageIcon,
+		AlertCircleIcon,
+		Code2Icon,
+		SettingsIcon,
+		ArrowDownIcon,
+		ArrowUpIcon,
+		ArrowRightIcon,
+		ArrowLeftIcon
+	} from "@lucide/svelte";
+	import {
+		TableSourceNode,
+		JoinNode,
+		FilterNode,
+		GroupNode,
+		ProjectionNode,
+		SortNode,
+		LimitNode
+	} from "./query-visual/nodes";
+	import {
+		layoutQueryVisualization,
+		DEFAULT_LAYOUT_OPTIONS,
+		type QueryLayoutOptions,
+		type LayoutDirection
+	} from "$lib/utils/query-visual-layout";
+	import type { Node, Edge, NodeTypes, ColorMode } from "@xyflow/svelte";
+	import { mode } from "mode-watcher";
+
+	const db = useDatabase();
+
+	// Map mode-watcher theme to xyflow colorMode
+	const colorMode: ColorMode = $derived(mode.current === "dark" ? "dark" : "light");
+
+	// Layout options state
+	let layoutOptions = $state<QueryLayoutOptions>({ ...DEFAULT_LAYOUT_OPTIONS });
+
+	// Custom node types
+	const nodeTypes: NodeTypes = {
+		tableSourceNode: TableSourceNode,
+		joinNode: JoinNode,
+		filterNode: FilterNode,
+		groupNode: GroupNode,
+		projectionNode: ProjectionNode,
+		sortNode: SortNode,
+		limitNode: LimitNode
+	};
+
+	// Compute flow data from active visualize tab
+	const flowData = $derived.by(() => {
+		const tab = db.state.activeVisualizeTab;
+		if (!tab?.parsedQuery) {
+			return { nodes: [] as Node[], edges: [] as Edge[] };
+		}
+		return layoutQueryVisualization(tab.parsedQuery, layoutOptions);
+	});
+
+	let nodes = $derived(flowData.nodes);
+	let edges = $derived(flowData.edges);
+
+	// Export functionality
+	let flowContainer: HTMLElement;
+
+	const getFlowElement = () => flowContainer?.querySelector('.svelte-flow') as HTMLElement | null;
+
+	const getImageOptions = () => ({
+		backgroundColor: mode.current === 'dark' ? '#0a0a0a' : '#ffffff',
+		filter: (node: Element) => {
+			return !node.classList?.contains('svelte-flow__minimap') &&
+				!node.classList?.contains('svelte-flow__controls');
+		}
+	});
+
+	const exportToPng = async () => {
+		const element = getFlowElement();
+		if (!element) return;
+
+		try {
+			const filePath = await save({
+				defaultPath: `query-visual-${Date.now()}.png`,
+				filters: [{ name: 'PNG Image', extensions: ['png'] }]
+			});
+			if (!filePath) return;
+
+			const dataUrl = await toPng(element, getImageOptions());
+			const base64 = dataUrl.split(',')[1];
+			const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+			await writeFile(filePath, bytes);
+			toast.success('PNG saved');
+		} catch (e) {
+			toast.error('Failed to export PNG');
+		}
+	};
+
+	// Truncate query for display
+	const queryPreview = $derived.by(() => {
+		const query = db.state.activeVisualizeTab?.sourceQuery || '';
+		if (query.length <= 100) return query;
+		return query.substring(0, 100) + '...';
+	});
+
+	// Direction options
+	const directions: { value: LayoutDirection; label: string; icon: typeof ArrowDownIcon }[] = [
+		{ value: 'TB', label: 'Top to Bottom', icon: ArrowDownIcon },
+		{ value: 'BT', label: 'Bottom to Top', icon: ArrowUpIcon },
+		{ value: 'LR', label: 'Left to Right', icon: ArrowRightIcon },
+		{ value: 'RL', label: 'Right to Left', icon: ArrowLeftIcon }
+	];
+
+	const setDirection = (dir: LayoutDirection) => {
+		layoutOptions = { ...layoutOptions, direction: dir };
+	};
+
+	const resetLayout = () => {
+		layoutOptions = { ...DEFAULT_LAYOUT_OPTIONS };
+	};
+</script>
+
+<div class="flex flex-col h-full">
+	{#if db.state.activeVisualizeTab}
+		{#if db.state.activeVisualizeTab.parsedQuery}
+			<!-- Summary Header -->
+			<div class="p-4 border-b bg-muted/30 shrink-0">
+				<div class="flex items-start justify-between mb-3">
+					<div>
+						<h2 class="text-lg font-semibold flex items-center gap-2">
+							<NetworkIcon class="size-5" />
+							Query Visualization
+						</h2>
+						<p class="text-sm text-muted-foreground mt-1 max-w-2xl">
+							Visual breakdown of the SQL query structure
+						</p>
+					</div>
+				</div>
+
+				<!-- Query Preview and Controls -->
+				<div class="flex items-center gap-2 flex-wrap">
+					<div class="flex items-center gap-2 text-xs bg-muted px-3 py-1.5 rounded-md max-w-xl">
+						<Code2Icon class="size-3 shrink-0 text-muted-foreground" />
+						<code class="font-mono truncate" title={db.state.activeVisualizeTab.sourceQuery}>
+							{queryPreview}
+						</code>
+					</div>
+
+					<!-- Layout Settings Popover -->
+					<Popover.Root>
+						<Popover.Trigger>
+							<Button variant="outline" size="sm" class="h-8">
+								<SettingsIcon class="size-4 me-2" />
+								Layout
+							</Button>
+						</Popover.Trigger>
+						<Popover.Content class="w-72" align="start">
+							<div class="space-y-4">
+								<div class="flex items-center justify-between">
+									<h4 class="font-medium text-sm">Layout Settings</h4>
+									<Button variant="ghost" size="sm" class="h-6 text-xs" onclick={resetLayout}>
+										Reset
+									</Button>
+								</div>
+
+								<!-- Direction -->
+								<div class="space-y-2">
+									<Label class="text-xs text-muted-foreground">Direction</Label>
+									<div class="grid grid-cols-4 gap-1">
+										{#each directions as dir}
+											<Button
+												variant={layoutOptions.direction === dir.value ? "default" : "outline"}
+												size="sm"
+												class="h-8 px-2"
+												onclick={() => setDirection(dir.value)}
+												title={dir.label}
+											>
+												<dir.icon class="size-4" />
+											</Button>
+										{/each}
+									</div>
+								</div>
+
+								<!-- Node Spacing -->
+								<div class="space-y-2">
+									<Label class="text-xs text-muted-foreground">Node Spacing (px)</Label>
+									<Input
+										type="number"
+										min={20}
+										max={200}
+										step={10}
+										value={layoutOptions.nodeSpacing}
+										oninput={(e) => {
+											const val = parseInt(e.currentTarget.value, 10);
+											if (!isNaN(val) && val >= 20 && val <= 200) {
+												layoutOptions = { ...layoutOptions, nodeSpacing: val };
+											}
+										}}
+										class="h-8"
+									/>
+								</div>
+
+								<!-- Rank Spacing -->
+								<div class="space-y-2">
+									<Label class="text-xs text-muted-foreground">Level Spacing (px)</Label>
+									<Input
+										type="number"
+										min={40}
+										max={300}
+										step={10}
+										value={layoutOptions.rankSpacing}
+										oninput={(e) => {
+											const val = parseInt(e.currentTarget.value, 10);
+											if (!isNaN(val) && val >= 40 && val <= 300) {
+												layoutOptions = { ...layoutOptions, rankSpacing: val };
+											}
+										}}
+										class="h-8"
+									/>
+								</div>
+							</div>
+						</Popover.Content>
+					</Popover.Root>
+
+					<!-- Export Dropdown -->
+					<DropdownMenu.Root>
+						<DropdownMenu.Trigger>
+							<Button variant="outline" size="sm" class="h-8">
+								<DownloadIcon class="size-4 me-2" />
+								Export
+							</Button>
+						</DropdownMenu.Trigger>
+						<DropdownMenu.Content>
+							<DropdownMenu.Item onclick={exportToPng}>
+								<ImageIcon class="size-4 me-2" />
+								Download PNG
+							</DropdownMenu.Item>
+						</DropdownMenu.Content>
+					</DropdownMenu.Root>
+				</div>
+			</div>
+
+			<!-- Flow Diagram -->
+			<div class="flex-1 min-h-0" bind:this={flowContainer}>
+				{#if nodes.length > 0}
+					<SvelteFlow
+						{nodes}
+						{edges}
+						{nodeTypes}
+						{colorMode}
+						fitView
+						minZoom={0.1}
+						maxZoom={2}
+						nodesDraggable={true}
+						nodesConnectable={false}
+						elementsSelectable={true}
+						deleteKey={null}
+						proOptions={{ hideAttribution: true }}
+					>
+						<Background />
+						<Controls />
+						<MiniMap />
+					</SvelteFlow>
+				{:else}
+					<div class="h-full flex items-center justify-center text-muted-foreground">
+						<div class="text-center">
+							<NetworkIcon class="size-12 mx-auto mb-2 opacity-20" />
+							<p class="text-sm">Unable to visualize query structure</p>
+						</div>
+					</div>
+				{/if}
+			</div>
+		{:else if db.state.activeVisualizeTab.parseError}
+			<!-- Parse error state -->
+			<div class="flex-1 flex items-center justify-center text-muted-foreground">
+				<div class="text-center max-w-md">
+					<AlertCircleIcon class="size-12 mx-auto mb-4 text-destructive opacity-50" />
+					<h3 class="text-lg font-semibold mb-2">Could not parse query</h3>
+					<p class="text-sm mb-4">{db.state.activeVisualizeTab.parseError}</p>
+					<div class="bg-muted p-3 rounded-md">
+						<code class="text-xs font-mono break-all text-left block">
+							{db.state.activeVisualizeTab.sourceQuery}
+						</code>
+					</div>
+				</div>
+			</div>
+		{:else}
+			<!-- Loading/empty state -->
+			<div class="flex-1 flex items-center justify-center text-muted-foreground">
+				<div class="text-center">
+					<NetworkIcon class="size-12 mx-auto mb-2 opacity-20" />
+					<p class="text-sm">Processing query...</p>
+				</div>
+			</div>
+		{/if}
+	{:else}
+		<!-- No tab selected state -->
+		<div class="flex-1 flex items-center justify-center text-muted-foreground">
+			<div class="text-center">
+				<NetworkIcon class="size-12 mx-auto mb-2 opacity-20" />
+				<p class="text-sm">No visualization selected</p>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/query-visual/nodes/filter-node.svelte
+++ b/src/lib/components/query-visual/nodes/filter-node.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { Handle, Position } from "@xyflow/svelte";
+	import { FilterIcon } from "@lucide/svelte";
+	import type { QueryFilter } from "$lib/types";
+
+	type Props = {
+		data: {
+			filter: QueryFilter;
+			filterType: 'WHERE' | 'HAVING';
+		};
+	};
+
+	let { data }: Props = $props();
+</script>
+
+<div
+	class="min-w-48 rounded-lg border-2 border-orange-500 bg-background shadow-md"
+>
+	<Handle type="target" position={Position.Top} class="!bg-orange-500" />
+
+	<div class="flex items-center gap-2 px-3 py-2 bg-orange-500/10 border-b border-orange-500/20 rounded-t-md">
+		<FilterIcon class="size-4 text-orange-500" />
+		<span class="text-sm font-semibold text-orange-700 dark:text-orange-300">
+			{data.filterType}
+		</span>
+	</div>
+	<div class="px-3 py-2">
+		<div class="text-xs font-mono bg-muted/50 px-2 py-1 rounded max-w-72 break-words">
+			{data.filter.expression}
+		</div>
+	</div>
+
+	<Handle type="source" position={Position.Bottom} class="!bg-orange-500" />
+</div>

--- a/src/lib/components/query-visual/nodes/group-node.svelte
+++ b/src/lib/components/query-visual/nodes/group-node.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { Handle, Position } from "@xyflow/svelte";
+	import { GroupIcon } from "@lucide/svelte";
+
+	type Props = {
+		data: {
+			columns: string[];
+		};
+	};
+
+	let { data }: Props = $props();
+</script>
+
+<div
+	class="min-w-40 rounded-lg border-2 border-teal-500 bg-background shadow-md"
+>
+	<Handle type="target" position={Position.Top} class="!bg-teal-500" />
+
+	<div class="flex items-center gap-2 px-3 py-2 bg-teal-500/10 border-b border-teal-500/20 rounded-t-md">
+		<GroupIcon class="size-4 text-teal-500" />
+		<span class="text-sm font-semibold text-teal-700 dark:text-teal-300">
+			GROUP BY
+		</span>
+	</div>
+	<div class="px-3 py-2 space-y-1">
+		{#each data.columns as column}
+			<div class="text-xs font-mono bg-muted/50 px-2 py-0.5 rounded">
+				{column}
+			</div>
+		{/each}
+	</div>
+
+	<Handle type="source" position={Position.Bottom} class="!bg-teal-500" />
+</div>

--- a/src/lib/components/query-visual/nodes/index.ts
+++ b/src/lib/components/query-visual/nodes/index.ts
@@ -1,0 +1,7 @@
+export { default as TableSourceNode } from './table-source-node.svelte';
+export { default as JoinNode } from './join-node.svelte';
+export { default as FilterNode } from './filter-node.svelte';
+export { default as GroupNode } from './group-node.svelte';
+export { default as ProjectionNode } from './projection-node.svelte';
+export { default as SortNode } from './sort-node.svelte';
+export { default as LimitNode } from './limit-node.svelte';

--- a/src/lib/components/query-visual/nodes/join-node.svelte
+++ b/src/lib/components/query-visual/nodes/join-node.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import { Handle, Position } from "@xyflow/svelte";
+	import { MergeIcon } from "@lucide/svelte";
+	import type { QueryJoin } from "$lib/types";
+
+	type Props = {
+		data: {
+			join: QueryJoin;
+		};
+	};
+
+	let { data }: Props = $props();
+
+	const joinColors: Record<string, { border: string; bg: string; text: string }> = {
+		INNER: { border: 'border-violet-500', bg: 'bg-violet-500/10', text: 'text-violet-500' },
+		LEFT: { border: 'border-amber-500', bg: 'bg-amber-500/10', text: 'text-amber-500' },
+		RIGHT: { border: 'border-orange-500', bg: 'bg-orange-500/10', text: 'text-orange-500' },
+		FULL: { border: 'border-emerald-500', bg: 'bg-emerald-500/10', text: 'text-emerald-500' },
+		CROSS: { border: 'border-rose-500', bg: 'bg-rose-500/10', text: 'text-rose-500' }
+	};
+
+	const colors = $derived(joinColors[data.join.type] || joinColors.INNER);
+</script>
+
+<div class="min-w-48 rounded-lg border-2 bg-background shadow-md {colors.border}">
+	<!-- Input handles (left side for sources) -->
+	<Handle type="target" position={Position.Top} id="left" style="left: 30%;" class="!bg-violet-500" />
+	<Handle type="target" position={Position.Top} id="right" style="left: 70%;" class="!bg-violet-500" />
+
+	<div class="flex items-center gap-2 px-3 py-2 border-b rounded-t-md {colors.bg}">
+		<MergeIcon class="size-4 {colors.text}" />
+		<span class="text-sm font-semibold {colors.text}">
+			{data.join.type} JOIN
+		</span>
+	</div>
+	<div class="px-3 py-2">
+		<!-- Joined table -->
+		<div class="text-sm font-medium mb-1">
+			{#if data.join.source.schema}
+				<span class="text-muted-foreground">{data.join.source.schema}.</span>
+			{/if}
+			{data.join.source.name}
+			{#if data.join.source.alias}
+				<span class="text-muted-foreground"> AS {data.join.source.alias}</span>
+			{/if}
+		</div>
+		<!-- ON condition -->
+		{#if data.join.condition}
+			<div class="text-xs text-muted-foreground font-mono bg-muted/50 px-2 py-1 rounded mt-1 max-w-64 break-words">
+				ON {data.join.condition}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Output handle -->
+	<Handle type="source" position={Position.Bottom} class="!bg-violet-500" />
+</div>

--- a/src/lib/components/query-visual/nodes/limit-node.svelte
+++ b/src/lib/components/query-visual/nodes/limit-node.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { Handle, Position } from "@xyflow/svelte";
+	import { ListEndIcon } from "@lucide/svelte";
+
+	type Props = {
+		data: {
+			limit: { count: number; offset?: number };
+		};
+	};
+
+	let { data }: Props = $props();
+</script>
+
+<div
+	class="min-w-32 rounded-lg border-2 border-pink-500 bg-background shadow-md"
+>
+	<Handle type="target" position={Position.Top} class="!bg-pink-500" />
+
+	<div class="flex items-center gap-2 px-3 py-2 bg-pink-500/10 border-b border-pink-500/20 rounded-t-md">
+		<ListEndIcon class="size-4 text-pink-500" />
+		<span class="text-sm font-semibold text-pink-700 dark:text-pink-300">
+			LIMIT
+		</span>
+	</div>
+	<div class="px-3 py-2">
+		<div class="text-sm font-mono">
+			{data.limit.count}
+			{#if data.limit.offset !== undefined && data.limit.offset > 0}
+				<span class="text-muted-foreground"> OFFSET {data.limit.offset}</span>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/src/lib/components/query-visual/nodes/projection-node.svelte
+++ b/src/lib/components/query-visual/nodes/projection-node.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import { Handle, Position } from "@xyflow/svelte";
+	import { ListIcon, FunctionSquareIcon } from "@lucide/svelte";
+	import type { QueryProjection } from "$lib/types";
+
+	type Props = {
+		data: {
+			projections: QueryProjection[];
+			distinct: boolean;
+		};
+	};
+
+	let { data }: Props = $props();
+
+	const maxDisplayed = 8;
+	const displayedProjections = $derived(data.projections.slice(0, maxDisplayed));
+	const remainingCount = $derived(Math.max(0, data.projections.length - maxDisplayed));
+</script>
+
+<div
+	class="min-w-48 rounded-lg border-2 border-slate-500 bg-background shadow-md"
+>
+	<Handle type="target" position={Position.Top} class="!bg-slate-500" />
+
+	<div class="flex items-center gap-2 px-3 py-2 bg-slate-500/10 border-b border-slate-500/20 rounded-t-md">
+		<ListIcon class="size-4 text-slate-500" />
+		<span class="text-sm font-semibold text-slate-700 dark:text-slate-300">
+			SELECT
+			{#if data.distinct}
+				<span class="text-xs font-normal ml-1 text-muted-foreground">DISTINCT</span>
+			{/if}
+		</span>
+	</div>
+	<div class="px-3 py-2 space-y-1 max-h-48 overflow-y-auto">
+		{#each displayedProjections as proj}
+			<div class="flex items-center gap-1.5 text-xs">
+				{#if proj.isAggregate}
+					<FunctionSquareIcon class="size-3 text-green-500 shrink-0" />
+				{/if}
+				<span
+					class="font-mono bg-muted/50 px-1.5 py-0.5 rounded truncate max-w-48"
+					class:text-green-700={proj.isAggregate}
+					class:dark:text-green-300={proj.isAggregate}
+					title={proj.expression + (proj.alias ? ` AS ${proj.alias}` : '')}
+				>
+					{proj.expression}
+					{#if proj.alias}
+						<span class="text-muted-foreground"> AS {proj.alias}</span>
+					{/if}
+				</span>
+			</div>
+		{/each}
+		{#if remainingCount > 0}
+			<div class="text-xs text-muted-foreground italic">
+				+{remainingCount} more column{remainingCount > 1 ? 's' : ''}
+			</div>
+		{/if}
+	</div>
+
+	<Handle type="source" position={Position.Bottom} class="!bg-slate-500" />
+</div>

--- a/src/lib/components/query-visual/nodes/sort-node.svelte
+++ b/src/lib/components/query-visual/nodes/sort-node.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { Handle, Position } from "@xyflow/svelte";
+	import { ArrowUpDownIcon, ArrowUpIcon, ArrowDownIcon } from "@lucide/svelte";
+	import type { QueryOrderBy } from "$lib/types";
+
+	type Props = {
+		data: {
+			orderBy: QueryOrderBy[];
+		};
+	};
+
+	let { data }: Props = $props();
+</script>
+
+<div
+	class="min-w-40 rounded-lg border-2 border-indigo-500 bg-background shadow-md"
+>
+	<Handle type="target" position={Position.Top} class="!bg-indigo-500" />
+
+	<div class="flex items-center gap-2 px-3 py-2 bg-indigo-500/10 border-b border-indigo-500/20 rounded-t-md">
+		<ArrowUpDownIcon class="size-4 text-indigo-500" />
+		<span class="text-sm font-semibold text-indigo-700 dark:text-indigo-300">
+			ORDER BY
+		</span>
+	</div>
+	<div class="px-3 py-2 space-y-1">
+		{#each data.orderBy as order}
+			<div class="flex items-center gap-1.5 text-xs">
+				{#if order.direction === 'ASC'}
+					<ArrowUpIcon class="size-3 text-indigo-500 shrink-0" />
+				{:else}
+					<ArrowDownIcon class="size-3 text-indigo-500 shrink-0" />
+				{/if}
+				<span class="font-mono bg-muted/50 px-1.5 py-0.5 rounded truncate max-w-40" title={order.expression}>
+					{order.expression}
+				</span>
+				<span class="text-muted-foreground">{order.direction}</span>
+			</div>
+		{/each}
+	</div>
+
+	<Handle type="source" position={Position.Bottom} class="!bg-indigo-500" />
+</div>

--- a/src/lib/components/query-visual/nodes/table-source-node.svelte
+++ b/src/lib/components/query-visual/nodes/table-source-node.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { Handle, Position } from "@xyflow/svelte";
+	import { TableIcon, FileSearchIcon } from "@lucide/svelte";
+	import type { QuerySource } from "$lib/types";
+
+	type Props = {
+		data: {
+			source: QuerySource;
+			isFirst: boolean;
+		};
+	};
+
+	let { data }: Props = $props();
+</script>
+
+<div
+	class="min-w-40 rounded-lg border-2 border-blue-500 bg-background shadow-md"
+>
+	<div class="flex items-center gap-2 px-3 py-2 bg-blue-500/10 border-b border-blue-500/20 rounded-t-md">
+		{#if data.source.type === 'subquery'}
+			<FileSearchIcon class="size-4 text-blue-500" />
+		{:else}
+			<TableIcon class="size-4 text-blue-500" />
+		{/if}
+		<span class="text-sm font-semibold text-blue-700 dark:text-blue-300">
+			{data.source.type === 'subquery' ? 'Subquery' : 'Table'}
+		</span>
+	</div>
+	<div class="px-3 py-2">
+		<div class="text-sm font-medium">
+			{#if data.source.schema}
+				<span class="text-muted-foreground">{data.source.schema}.</span>
+			{/if}
+			{data.source.name}
+		</div>
+		{#if data.source.alias}
+			<div class="text-xs text-muted-foreground mt-0.5">
+				AS {data.source.alias}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Output handle for connecting to next node -->
+	<Handle type="source" position={Position.Bottom} class="!bg-blue-500" />
+
+	<!-- Input handle if not first node -->
+	{#if !data.isFirst}
+		<Handle type="target" position={Position.Top} class="!bg-blue-500" />
+	{/if}
+</div>

--- a/src/lib/db/sql-ast-parser.ts
+++ b/src/lib/db/sql-ast-parser.ts
@@ -1,0 +1,528 @@
+/**
+ * SQL AST Parser wrapper for query visualization.
+ * Uses node-sql-parser to parse SQL and extract structured information.
+ */
+import { Parser } from 'node-sql-parser';
+import type {
+	ParsedQueryVisual,
+	QuerySource,
+	QueryJoin,
+	QueryFilter,
+	QueryProjection,
+	QueryOrderBy
+} from '$lib/types';
+import type { DatabaseType } from '$lib/types';
+
+// Parser instance
+const parser = new Parser();
+
+// Map database types to parser dialects
+const DIALECT_MAP: Record<DatabaseType, string> = {
+	postgres: 'PostgreSQL',
+	mysql: 'MySQL',
+	mariadb: 'MariaDB',
+	sqlite: 'SQLite',
+	mssql: 'TransactSQL',
+	duckdb: 'PostgreSQL' // DuckDB is mostly PostgreSQL compatible
+};
+
+/**
+ * Aggregate function names to detect in expressions.
+ */
+const AGGREGATE_FUNCTIONS = new Set([
+	'count',
+	'sum',
+	'avg',
+	'min',
+	'max',
+	'array_agg',
+	'string_agg',
+	'group_concat',
+	'json_agg',
+	'jsonb_agg',
+	'bool_and',
+	'bool_or',
+	'every',
+	'stddev',
+	'variance',
+	'first',
+	'last',
+	'median',
+	'mode',
+	'percentile_cont',
+	'percentile_disc'
+]);
+
+/**
+ * Parse a SQL query and extract structured information for visualization.
+ */
+export function parseQueryForVisualization(
+	sql: string,
+	dbType: DatabaseType = 'postgres'
+): ParsedQueryVisual | null {
+	try {
+		const dialect = DIALECT_MAP[dbType] || 'PostgreSQL';
+		const ast = parser.astify(sql, { database: dialect });
+
+		// Handle multiple statements - take the first one
+		const statement = Array.isArray(ast) ? ast[0] : ast;
+
+		if (!statement) {
+			return null;
+		}
+
+		return convertAstToVisual(statement);
+	} catch (error) {
+		console.error('SQL parse error:', error);
+		return null;
+	}
+}
+
+/**
+ * Convert parser AST to our visualization structure.
+ */
+function convertAstToVisual(ast: any): ParsedQueryVisual | null {
+	// Default structure
+	const result: ParsedQueryVisual = {
+		type: 'other',
+		sources: [],
+		joins: [],
+		filters: [],
+		groupBy: null,
+		having: null,
+		projections: [],
+		orderBy: [],
+		limit: null,
+		distinct: false
+	};
+
+	// Determine query type
+	if (ast.type === 'select') {
+		result.type = 'select';
+		result.distinct = ast.distinct === 'DISTINCT';
+
+		// Extract sources from FROM clause
+		if (ast.from) {
+			result.sources = extractSources(ast.from);
+		}
+
+		// Extract JOINs
+		if (ast.from) {
+			result.joins = extractJoins(ast.from);
+		}
+
+		// Extract WHERE clause
+		if (ast.where) {
+			result.filters = [extractFilter(ast.where)];
+		}
+
+		// Extract GROUP BY
+		if (ast.groupby) {
+			// groupby can be an array or an object with columns property
+			const groupbyList = Array.isArray(ast.groupby)
+				? ast.groupby
+				: ast.groupby.columns || ast.groupby.expr || [ast.groupby];
+			result.groupBy = Array.isArray(groupbyList)
+				? groupbyList.map((g: any) => expressionToString(g.expr || g))
+				: [expressionToString(groupbyList)];
+		}
+
+		// Extract HAVING
+		if (ast.having) {
+			result.having = extractFilter(ast.having);
+		}
+
+		// Extract SELECT columns
+		if (ast.columns) {
+			result.projections = extractProjections(ast.columns);
+		}
+
+		// Extract ORDER BY
+		if (ast.orderby) {
+			result.orderBy = ast.orderby.map((o: any) => ({
+				expression: expressionToString(o.expr),
+				direction: (o.type?.toUpperCase() || 'ASC') as 'ASC' | 'DESC'
+			}));
+		}
+
+		// Extract LIMIT
+		if (ast.limit) {
+			const limitVal = ast.limit.value?.[0]?.value ?? ast.limit.value ?? null;
+			const offsetVal = ast.limit.value?.[1]?.value ?? null;
+			if (limitVal !== null) {
+				result.limit = {
+					count: typeof limitVal === 'number' ? limitVal : parseInt(limitVal, 10),
+					offset: offsetVal !== null ? (typeof offsetVal === 'number' ? offsetVal : parseInt(offsetVal, 10)) : undefined
+				};
+			}
+		}
+	} else if (ast.type === 'insert') {
+		result.type = 'insert';
+		if (ast.table) {
+			result.sources = [
+				{
+					type: 'table',
+					schema: ast.table[0]?.db,
+					name: ast.table[0]?.table || 'unknown',
+					alias: ast.table[0]?.as
+				}
+			];
+		}
+	} else if (ast.type === 'update') {
+		result.type = 'update';
+		if (ast.table) {
+			const tables = Array.isArray(ast.table) ? ast.table : [ast.table];
+			result.sources = tables.map((t: any) => ({
+				type: 'table' as const,
+				schema: t.db,
+				name: t.table || 'unknown',
+				alias: t.as
+			}));
+		}
+		if (ast.where) {
+			result.filters = [extractFilter(ast.where)];
+		}
+	} else if (ast.type === 'delete') {
+		result.type = 'delete';
+		if (ast.from) {
+			result.sources = extractSources(ast.from);
+		}
+		if (ast.where) {
+			result.filters = [extractFilter(ast.where)];
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Extract table sources from FROM clause.
+ */
+function extractSources(fromClause: any[]): QuerySource[] {
+	const sources: QuerySource[] = [];
+
+	for (const item of fromClause) {
+		if (item.type === 'dual') {
+			// Skip DUAL pseudo-table
+			continue;
+		}
+
+		// Check if this is a table reference
+		if (item.table) {
+			sources.push({
+				type: 'table',
+				schema: item.db || undefined,
+				name: item.table,
+				alias: item.as || undefined
+			});
+		}
+		// Check for subquery
+		else if (item.expr && item.expr.ast) {
+			const subquery = convertAstToVisual(item.expr.ast);
+			sources.push({
+				type: 'subquery',
+				name: item.as || 'subquery',
+				alias: item.as || undefined,
+				subquery: subquery || undefined
+			});
+		}
+	}
+
+	return sources;
+}
+
+/**
+ * Extract JOIN clauses from FROM clause.
+ */
+function extractJoins(fromClause: any[]): QueryJoin[] {
+	const joins: QueryJoin[] = [];
+
+	for (const item of fromClause) {
+		if (item.join) {
+			const joinType = normalizeJoinType(item.join);
+			const source: QuerySource = item.table
+				? {
+						type: 'table',
+						schema: item.db || undefined,
+						name: item.table,
+						alias: item.as || undefined
+					}
+				: item.expr?.ast
+					? {
+							type: 'subquery',
+							name: item.as || 'subquery',
+							alias: item.as || undefined,
+							subquery: convertAstToVisual(item.expr.ast) || undefined
+						}
+					: {
+							type: 'table',
+							name: 'unknown'
+						};
+
+			const condition = item.on ? expressionToString(item.on) : '';
+
+			joins.push({
+				type: joinType,
+				source,
+				condition
+			});
+		}
+	}
+
+	return joins;
+}
+
+/**
+ * Normalize join type string to our enum.
+ */
+function normalizeJoinType(joinStr: string): 'INNER' | 'LEFT' | 'RIGHT' | 'FULL' | 'CROSS' {
+	const upper = joinStr.toUpperCase();
+	if (upper.includes('LEFT')) return 'LEFT';
+	if (upper.includes('RIGHT')) return 'RIGHT';
+	if (upper.includes('FULL')) return 'FULL';
+	if (upper.includes('CROSS')) return 'CROSS';
+	return 'INNER';
+}
+
+/**
+ * Extract filter from WHERE/HAVING clause.
+ */
+function extractFilter(whereClause: any): QueryFilter {
+	if (!whereClause) {
+		return { expression: '' };
+	}
+
+	// Handle binary expressions (AND, OR, etc.)
+	if (whereClause.type === 'binary_expr') {
+		const operator = whereClause.operator?.toUpperCase();
+
+		// If it's AND/OR, create compound filter
+		if (operator === 'AND' || operator === 'OR') {
+			return {
+				expression: expressionToString(whereClause),
+				operator,
+				children: [extractFilter(whereClause.left), extractFilter(whereClause.right)]
+			};
+		}
+	}
+
+	// Simple expression
+	return {
+		expression: expressionToString(whereClause)
+	};
+}
+
+/**
+ * Extract projections (SELECT columns).
+ */
+function extractProjections(columns: any[] | '*'): QueryProjection[] {
+	if (columns === '*') {
+		return [{ expression: '*', isAggregate: false }];
+	}
+
+	return columns.map((col: any) => {
+		const expr = col.expr;
+		const alias = col.as || undefined;
+		const exprStr = expressionToString(expr);
+
+		// Check for aggregate function
+		const { isAggregate, aggregateFunction } = detectAggregate(expr);
+
+		return {
+			expression: exprStr,
+			alias,
+			isAggregate,
+			aggregateFunction
+		};
+	});
+}
+
+/**
+ * Detect if an expression contains an aggregate function.
+ */
+function detectAggregate(expr: any): { isAggregate: boolean; aggregateFunction?: string } {
+	if (!expr) {
+		return { isAggregate: false };
+	}
+
+	// Check if this is a function call
+	if (expr.type === 'aggr_func' || expr.type === 'function') {
+		const funcName = (expr.name || '').toLowerCase();
+		if (AGGREGATE_FUNCTIONS.has(funcName)) {
+			return { isAggregate: true, aggregateFunction: funcName.toUpperCase() };
+		}
+	}
+
+	// Recursively check nested expressions
+	if (expr.args) {
+		const args = Array.isArray(expr.args) ? expr.args : [expr.args];
+		for (const arg of args) {
+			const result = detectAggregate(arg.expr || arg);
+			if (result.isAggregate) {
+				return result;
+			}
+		}
+	}
+
+	if (expr.left) {
+		const result = detectAggregate(expr.left);
+		if (result.isAggregate) return result;
+	}
+
+	if (expr.right) {
+		const result = detectAggregate(expr.right);
+		if (result.isAggregate) return result;
+	}
+
+	return { isAggregate: false };
+}
+
+/**
+ * Convert an AST expression node to a readable string.
+ */
+function expressionToString(expr: any): string {
+	if (!expr) return '';
+
+	// String, number, or null literal
+	if (expr.type === 'string' || expr.type === 'single_quote_string') {
+		return `'${expr.value}'`;
+	}
+	if (expr.type === 'number') {
+		return String(expr.value);
+	}
+	if (expr.type === 'null') {
+		return 'NULL';
+	}
+	if (expr.type === 'bool') {
+		return expr.value ? 'TRUE' : 'FALSE';
+	}
+
+	// Column reference
+	if (expr.type === 'column_ref') {
+		const parts: string[] = [];
+		if (expr.table) parts.push(expr.table);
+		parts.push(expr.column);
+		return parts.join('.');
+	}
+
+	// Star/wildcard
+	if (expr.type === 'star') {
+		return expr.table ? `${expr.table}.*` : '*';
+	}
+
+	// Binary expression
+	if (expr.type === 'binary_expr') {
+		const left = expressionToString(expr.left);
+		const right = expressionToString(expr.right);
+		const op = expr.operator || '=';
+		return `${left} ${op} ${right}`;
+	}
+
+	// Unary expression
+	if (expr.type === 'unary_expr') {
+		return `${expr.operator || ''} ${expressionToString(expr.expr)}`.trim();
+	}
+
+	// Function call
+	if (expr.type === 'function' || expr.type === 'aggr_func') {
+		const funcName = expr.name || 'FUNC';
+		const args = expr.args;
+
+		if (args) {
+			if (args.type === 'star') {
+				return `${funcName}(*)`;
+			}
+			if (args.distinct) {
+				const argStr = Array.isArray(args.expr)
+					? args.expr.map((a: any) => expressionToString(a)).join(', ')
+					: expressionToString(args.expr);
+				return `${funcName}(DISTINCT ${argStr})`;
+			}
+			const argStr = Array.isArray(args.expr)
+				? args.expr.map((a: any) => expressionToString(a)).join(', ')
+				: expressionToString(args.expr);
+			return `${funcName}(${argStr})`;
+		}
+		return `${funcName}()`;
+	}
+
+	// CASE expression
+	if (expr.type === 'case') {
+		let result = 'CASE';
+		if (expr.expr) {
+			result += ` ${expressionToString(expr.expr)}`;
+		}
+		if (expr.args) {
+			for (const arg of expr.args) {
+				if (arg.type === 'when') {
+					result += ` WHEN ${expressionToString(arg.cond)} THEN ${expressionToString(arg.result)}`;
+				} else if (arg.type === 'else') {
+					result += ` ELSE ${expressionToString(arg.result)}`;
+				}
+			}
+		}
+		result += ' END';
+		return result;
+	}
+
+	// IN expression
+	if (expr.type === 'expr_list') {
+		const values = expr.value?.map((v: any) => expressionToString(v)).join(', ') || '';
+		return `(${values})`;
+	}
+
+	// BETWEEN expression
+	if (expr.type === 'between') {
+		return `${expressionToString(expr.expr)} BETWEEN ${expressionToString(expr.start)} AND ${expressionToString(expr.end)}`;
+	}
+
+	// LIKE expression
+	if (expr.type === 'like') {
+		const notStr = expr.not ? 'NOT ' : '';
+		return `${expressionToString(expr.expr)} ${notStr}LIKE ${expressionToString(expr.right)}`;
+	}
+
+	// Cast expression
+	if (expr.type === 'cast') {
+		return `CAST(${expressionToString(expr.expr)} AS ${expr.target?.dataType || 'unknown'})`;
+	}
+
+	// Subquery
+	if (expr.ast) {
+		return '(subquery)';
+	}
+
+	// Parameter placeholder
+	if (expr.type === 'param') {
+		return expr.value ? `$${expr.value}` : '?';
+	}
+
+	// Default: try to use value directly
+	if (typeof expr.value !== 'undefined') {
+		return String(expr.value);
+	}
+
+	return '';
+}
+
+/**
+ * Try to get a more user-friendly error message for parse failures.
+ */
+export function getParseError(sql: string, dbType: DatabaseType = 'postgres'): string | null {
+	try {
+		const dialect = DIALECT_MAP[dbType] || 'PostgreSQL';
+		parser.astify(sql, { database: dialect });
+		return null;
+	} catch (error: any) {
+		// Extract meaningful error message
+		if (error.message) {
+			// Clean up error message
+			const msg = error.message
+				.replace(/Syntax error at line \d+ col \d+:/, 'Syntax error:')
+				.replace(/\n\n[\s\S]*$/, '')
+				.trim();
+			return msg || 'Unable to parse SQL query';
+		}
+		return 'Unable to parse SQL query';
+	}
+}

--- a/src/lib/hooks/database.svelte.ts
+++ b/src/lib/hooks/database.svelte.ts
@@ -16,6 +16,7 @@ import { ExplainTabManager } from "./database/explain-tabs.svelte.js";
 import { ErdTabManager } from "./database/erd-tabs.svelte.js";
 import { StatisticsTabManager } from "./database/statistics-tabs.svelte.js";
 import { CanvasTabManager } from "./database/canvas-tabs.svelte.js";
+import { VisualizeTabManager } from "./database/visualize-tabs.svelte.js";
 import { ProjectManager } from "./database/project-manager.svelte.js";
 import { LabelManager } from "./database/label-manager.svelte.js";
 import { StarterTabManager } from "./database/starter-tabs.svelte.js";
@@ -51,6 +52,7 @@ class UseDatabase {
   readonly erdTabs: ErdTabManager;
   readonly statisticsTabs: StatisticsTabManager;
   readonly canvasTabs: CanvasTabManager;
+  readonly visualizeTabs: VisualizeTabManager;
   readonly starterTabs: StarterTabManager;
   readonly canvasState: CanvasState;
   readonly canvas: CanvasManager;
@@ -68,7 +70,7 @@ class UseDatabase {
       this.persistence.scheduleConnectionData(connectionId);
     };
 
-    const setActiveView = (view: "query" | "schema" | "explain" | "erd" | "statistics" | "canvas") => {
+    const setActiveView = (view: "query" | "schema" | "explain" | "erd" | "statistics" | "canvas" | "visualize") => {
       this.ui.setActiveView(view);
     };
 
@@ -101,6 +103,7 @@ class UseDatabase {
       }
     );
     this.canvasTabs = new CanvasTabManager(this.state, this.tabs, scheduleProjectPersistence, setActiveView);
+    this.visualizeTabs = new VisualizeTabManager(this.state, this.tabs, scheduleProjectPersistence, setActiveView);
     this.starterTabs = new StarterTabManager(this.state, scheduleProjectPersistence);
 
     // Canvas

--- a/src/lib/hooks/database/state.svelte.ts
+++ b/src/lib/hooks/database/state.svelte.ts
@@ -10,6 +10,7 @@ import type {
 	ErdTab,
 	StatisticsTab,
 	CanvasTab,
+	VisualizeTab,
 	Project,
 	StarterTab
 } from '$lib/types';
@@ -63,6 +64,9 @@ export class DatabaseState {
 	canvasTabsByProject = $state<Record<string, CanvasTab[]>>({});
 	activeCanvasTabIdByProject = $state<Record<string, string | null>>({});
 
+	visualizeTabsByProject = $state<Record<string, VisualizeTab[]>>({});
+	activeVisualizeTabIdByProject = $state<Record<string, string | null>>({});
+
 	// Saved canvases per project
 	savedCanvasesByProject = $state<Record<string, SavedCanvas[]>>({});
 
@@ -83,7 +87,7 @@ export class DatabaseState {
 	isAIOpen = $state(false);
 
 	// === VIEW STATE ===
-	activeView = $state<'query' | 'schema' | 'explain' | 'erd' | 'statistics' | 'canvas'>('query');
+	activeView = $state<'query' | 'schema' | 'explain' | 'erd' | 'statistics' | 'canvas' | 'visualize'>('query');
 
 	// === PROJECT DERIVED VALUES ===
 
@@ -223,6 +227,21 @@ export class DatabaseState {
 	savedCanvases = $derived(
 		this.activeProjectId ? (this.savedCanvasesByProject[this.activeProjectId] ?? []) : []
 	);
+
+	// === VISUALIZE TAB DERIVED VALUES ===
+
+	// Derived: visualize tabs for active project
+	visualizeTabs = $derived(
+		this.activeProjectId ? (this.visualizeTabsByProject[this.activeProjectId] ?? []) : []
+	);
+
+	// Derived: active visualize tab ID for active project
+	activeVisualizeTabId = $derived(
+		this.activeProjectId ? (this.activeVisualizeTabIdByProject[this.activeProjectId] ?? null) : null
+	);
+
+	// Derived: active visualize tab object
+	activeVisualizeTab = $derived(this.visualizeTabs.find((t) => t.id === this.activeVisualizeTabId) || null);
 
 	// === STARTER TAB DERIVED VALUES ===
 

--- a/src/lib/hooks/database/tab-ordering.svelte.ts
+++ b/src/lib/hooks/database/tab-ordering.svelte.ts
@@ -1,4 +1,4 @@
-import type { QueryTab, SchemaTab, ExplainTab, ErdTab, StatisticsTab, CanvasTab } from '$lib/types';
+import type { QueryTab, SchemaTab, ExplainTab, ErdTab, StatisticsTab, CanvasTab, VisualizeTab } from '$lib/types';
 import type { DatabaseState } from './state.svelte.js';
 
 /**
@@ -100,8 +100,8 @@ export class TabOrderingManager {
 	 */
 	get ordered(): Array<{
 		id: string;
-		type: 'query' | 'schema' | 'explain' | 'erd' | 'statistics' | 'canvas';
-		tab: QueryTab | SchemaTab | ExplainTab | ErdTab | StatisticsTab | CanvasTab;
+		type: 'query' | 'schema' | 'explain' | 'erd' | 'statistics' | 'canvas' | 'visualize';
+		tab: QueryTab | SchemaTab | ExplainTab | ErdTab | StatisticsTab | CanvasTab | VisualizeTab;
 	}> {
 		if (!this.state.activeProjectId) return [];
 
@@ -112,11 +112,12 @@ export class TabOrderingManager {
 		const erdTabs = this.state.erdTabs || [];
 		const statisticsTabs = this.state.statisticsTabs || [];
 		const canvasTabs = this.state.canvasTabs || [];
+		const visualizeTabs = this.state.visualizeTabs || [];
 
 		const allTabsUnordered: Array<{
 			id: string;
-			type: 'query' | 'schema' | 'explain' | 'erd' | 'statistics' | 'canvas';
-			tab: QueryTab | SchemaTab | ExplainTab | ErdTab | StatisticsTab | CanvasTab;
+			type: 'query' | 'schema' | 'explain' | 'erd' | 'statistics' | 'canvas' | 'visualize';
+			tab: QueryTab | SchemaTab | ExplainTab | ErdTab | StatisticsTab | CanvasTab | VisualizeTab;
 		}> = [];
 
 		for (const t of queryTabs) {
@@ -136,6 +137,9 @@ export class TabOrderingManager {
 		}
 		for (const t of canvasTabs) {
 			allTabsUnordered.push({ id: t.id, type: 'canvas', tab: t });
+		}
+		for (const t of visualizeTabs) {
+			allTabsUnordered.push({ id: t.id, type: 'visualize', tab: t });
 		}
 
 		const order = this.state.tabOrderByProject[this.state.activeProjectId] ?? [];

--- a/src/lib/hooks/database/ui-state.svelte.ts
+++ b/src/lib/hooks/database/ui-state.svelte.ts
@@ -39,7 +39,7 @@ export class UIStateManager {
     }, 1000);
   }
 
-  setActiveView(view: "query" | "schema" | "explain" | "erd" | "statistics" | "canvas") {
+  setActiveView(view: "query" | "schema" | "explain" | "erd" | "statistics" | "canvas" | "visualize") {
     this.state.activeView = view;
     this.schedulePersistence(this.state.activeProjectId);
   }

--- a/src/lib/hooks/database/visualize-tabs.svelte.ts
+++ b/src/lib/hooks/database/visualize-tabs.svelte.ts
@@ -1,0 +1,117 @@
+import { toast } from 'svelte-sonner';
+import type { VisualizeTab } from '$lib/types';
+import type { DatabaseState } from './state.svelte.js';
+import type { TabOrderingManager } from './tab-ordering.svelte.js';
+import { parseQueryForVisualization, getParseError } from '$lib/db/sql-ast-parser';
+import { getStatementAtOffset } from '$lib/db/sql-parser';
+
+/**
+ * Manages query visualizer tabs: parse, visualize, remove, set active.
+ * Tabs are organized per-project.
+ */
+export class VisualizeTabManager {
+	constructor(
+		private state: DatabaseState,
+		private tabOrdering: TabOrderingManager,
+		private schedulePersistence: (projectId: string | null) => void,
+		private setActiveView: (view: 'query' | 'schema' | 'explain' | 'erd' | 'statistics' | 'canvas' | 'visualize') => void
+	) {}
+
+	/**
+	 * Visualize a query from a query tab.
+	 * If cursorOffset is provided, visualizes only the statement at that cursor position.
+	 */
+	visualize(tabId: string, cursorOffset?: number): void {
+		if (!this.state.activeProjectId || !this.state.activeConnection) return;
+
+		const projectId = this.state.activeProjectId;
+		const tabs = this.state.queryTabsByProject[projectId] ?? [];
+		const tab = tabs.find((t) => t.id === tabId);
+		if (!tab || !tab.query.trim()) {
+			toast.error('No query to visualize');
+			return;
+		}
+
+		// Get the statement to visualize based on cursor position
+		const dbType = this.state.activeConnection.type;
+		let queryToVisualize = tab.query;
+
+		if (cursorOffset !== undefined) {
+			const statement = getStatementAtOffset(tab.query, cursorOffset, dbType);
+			if (statement) {
+				queryToVisualize = statement.sql;
+			}
+		}
+
+		if (!queryToVisualize.trim()) {
+			toast.error('No query to visualize');
+			return;
+		}
+
+		// Parse the query
+		const parsedQuery = parseQueryForVisualization(queryToVisualize, dbType);
+		const parseError = parsedQuery ? undefined : getParseError(queryToVisualize, dbType) || 'Unable to parse query';
+
+		// Create a new visualize tab
+		const visualizeTabs = this.state.visualizeTabsByProject[projectId] ?? [];
+		const visualizeTabId = `visualize-${Date.now()}`;
+		const queryPreview = queryToVisualize.substring(0, 30).replace(/\s+/g, ' ').trim();
+		const newVisualizeTab: VisualizeTab = $state({
+			id: visualizeTabId,
+			name: `Visual: ${queryPreview}...`,
+			sourceQuery: queryToVisualize,
+			parsedQuery,
+			parseError
+		});
+
+		this.state.visualizeTabsByProject = {
+			...this.state.visualizeTabsByProject,
+			[projectId]: [...visualizeTabs, newVisualizeTab]
+		};
+
+		this.tabOrdering.add(visualizeTabId);
+
+		// Set as active and switch view
+		this.state.activeVisualizeTabIdByProject = {
+			...this.state.activeVisualizeTabIdByProject,
+			[projectId]: visualizeTabId
+		};
+		this.setActiveView('visualize');
+		this.schedulePersistence(projectId);
+
+		if (parseError) {
+			toast.error(`Parse warning: ${parseError}`);
+		}
+	}
+
+	/**
+	 * Remove a visualize tab by ID.
+	 */
+	remove(id: string): void {
+		this.tabOrdering.removeTabGeneric(
+			() => this.state.visualizeTabsByProject,
+			(r) => (this.state.visualizeTabsByProject = r),
+			() => this.state.activeVisualizeTabIdByProject,
+			(r) => (this.state.activeVisualizeTabIdByProject = r),
+			id
+		);
+		this.schedulePersistence(this.state.activeProjectId);
+		// Switch to query view if no visualize tabs left
+		if (this.state.activeProjectId && this.state.visualizeTabs.length === 0) {
+			this.setActiveView('query');
+		}
+	}
+
+	/**
+	 * Set the active visualize tab by ID.
+	 */
+	setActive(id: string): void {
+		if (!this.state.activeProjectId) return;
+
+		this.state.activeVisualizeTabIdByProject = {
+			...this.state.activeVisualizeTabIdByProject,
+			[this.state.activeProjectId]: id
+		};
+		this.schedulePersistence(this.state.activeProjectId);
+	}
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -46,6 +46,17 @@ export type { ChartType, ChartConfig, ResultViewMode } from './chart';
 // Canvas types
 export type { CanvasTab } from './canvas';
 
+// Visualize types
+export type {
+	VisualizeTab,
+	ParsedQueryVisual,
+	QuerySource,
+	QueryJoin,
+	QueryFilter,
+	QueryProjection,
+	QueryOrderBy
+} from './visualize';
+
 // Statistics types
 export type {
 	TableSizeInfo,

--- a/src/lib/types/persisted.ts
+++ b/src/lib/types/persisted.ts
@@ -83,6 +83,18 @@ export interface PersistedCanvasTab {
 }
 
 /**
+ * Persisted query visualizer tab state.
+ */
+export interface PersistedVisualizeTab {
+	/** Tab identifier */
+	id: string;
+	/** Tab display name */
+	name: string;
+	/** The original SQL query being visualized */
+	sourceQuery: string;
+}
+
+/**
  * Persisted starter tab state.
  */
 export interface PersistedStarterTab {
@@ -159,7 +171,7 @@ export interface PersistedQueryHistoryItem {
 /**
  * View type options for the main workspace.
  */
-export type ActiveViewType = 'query' | 'schema' | 'explain' | 'erd' | 'statistics' | 'canvas';
+export type ActiveViewType = 'query' | 'schema' | 'explain' | 'erd' | 'statistics' | 'canvas' | 'visualize';
 
 /**
  * Complete persisted state for a single connection.
@@ -180,6 +192,8 @@ export interface PersistedConnectionState {
 	statisticsTabs: PersistedStatisticsTab[];
 	/** Canvas workspace tabs */
 	canvasTabs: PersistedCanvasTab[];
+	/** Query visualizer tabs */
+	visualizeTabs: PersistedVisualizeTab[];
 	/** Ordered list of all tab IDs for drag-drop ordering */
 	tabOrder: string[];
 	/** Currently active query tab */
@@ -194,6 +208,8 @@ export interface PersistedConnectionState {
 	activeStatisticsTabId: string | null;
 	/** Currently active canvas tab */
 	activeCanvasTabId: string | null;
+	/** Currently active visualize tab */
+	activeVisualizeTabId: string | null;
 	/** Which view type is currently active */
 	activeView: ActiveViewType;
 	/** Saved queries for this connection */

--- a/src/lib/types/visualize.ts
+++ b/src/lib/types/visualize.ts
@@ -1,0 +1,110 @@
+/**
+ * Query Visualizer types.
+ * @module types/visualize
+ */
+
+/**
+ * Represents an open query visualizer tab.
+ */
+export interface VisualizeTab {
+	/** Unique tab identifier */
+	id: string;
+	/** Tab display name */
+	name: string;
+	/** The original SQL query being visualized */
+	sourceQuery: string;
+	/** Parsed query structure for visualization */
+	parsedQuery: ParsedQueryVisual | null;
+	/** Error message if parsing failed */
+	parseError?: string;
+}
+
+/**
+ * Complete parsed query structure for visualization.
+ */
+export interface ParsedQueryVisual {
+	/** Type of query (SELECT, INSERT, UPDATE, DELETE) */
+	type: 'select' | 'insert' | 'update' | 'delete' | 'other';
+	/** Tables and subqueries in FROM clause */
+	sources: QuerySource[];
+	/** JOIN clauses */
+	joins: QueryJoin[];
+	/** WHERE conditions */
+	filters: QueryFilter[];
+	/** GROUP BY columns */
+	groupBy: string[] | null;
+	/** HAVING clause filter */
+	having: QueryFilter | null;
+	/** SELECT columns/expressions */
+	projections: QueryProjection[];
+	/** ORDER BY clauses */
+	orderBy: QueryOrderBy[];
+	/** LIMIT/OFFSET */
+	limit: { count: number; offset?: number } | null;
+	/** DISTINCT flag */
+	distinct: boolean;
+}
+
+/**
+ * A table or subquery source in FROM clause.
+ */
+export interface QuerySource {
+	/** Type of source */
+	type: 'table' | 'subquery';
+	/** Schema name (if specified) */
+	schema?: string;
+	/** Table name or subquery alias */
+	name: string;
+	/** Alias for the source */
+	alias?: string;
+	/** For subqueries, the nested parsed query */
+	subquery?: ParsedQueryVisual;
+}
+
+/**
+ * A JOIN clause.
+ */
+export interface QueryJoin {
+	/** Type of join */
+	type: 'INNER' | 'LEFT' | 'RIGHT' | 'FULL' | 'CROSS';
+	/** The joined table/source */
+	source: QuerySource;
+	/** ON condition as readable string */
+	condition: string;
+}
+
+/**
+ * A filter condition (WHERE or HAVING).
+ */
+export interface QueryFilter {
+	/** The full condition as readable string */
+	expression: string;
+	/** Operator used (AND, OR, etc) at top level */
+	operator?: string;
+	/** For compound conditions, nested filters */
+	children?: QueryFilter[];
+}
+
+/**
+ * A SELECT column/expression.
+ */
+export interface QueryProjection {
+	/** The expression or column name */
+	expression: string;
+	/** Alias if specified */
+	alias?: string;
+	/** Whether this is an aggregate function */
+	isAggregate: boolean;
+	/** Aggregate function name if applicable */
+	aggregateFunction?: string;
+}
+
+/**
+ * An ORDER BY clause.
+ */
+export interface QueryOrderBy {
+	/** Column or expression */
+	expression: string;
+	/** Sort direction */
+	direction: 'ASC' | 'DESC';
+}

--- a/src/lib/utils/query-visual-layout.ts
+++ b/src/lib/utils/query-visual-layout.ts
@@ -1,0 +1,352 @@
+/**
+ * Layout engine for query visualization.
+ * Converts parsed query structure to xyflow nodes and edges.
+ */
+import dagre from "@dagrejs/dagre";
+import { Position } from "@xyflow/svelte";
+import type { Node, Edge } from "@xyflow/svelte";
+import type { ParsedQueryVisual } from "$lib/types";
+
+const NODE_WIDTH = 200;
+const NODE_HEIGHT = 80;
+
+/**
+ * Node type definitions for the query visualization.
+ */
+export type QueryVisualNodeType =
+	| 'tableSourceNode'
+	| 'joinNode'
+	| 'filterNode'
+	| 'groupNode'
+	| 'projectionNode'
+	| 'sortNode'
+	| 'limitNode';
+
+/**
+ * Layout direction options.
+ */
+export type LayoutDirection = 'TB' | 'BT' | 'LR' | 'RL';
+
+/**
+ * Layout alignment options.
+ */
+export type LayoutAlign = 'UL' | 'UR' | 'DL' | 'DR';
+
+/**
+ * Configurable layout options for the query visualization.
+ */
+export interface QueryLayoutOptions {
+	/** Layout direction: TB (top-bottom), BT (bottom-top), LR (left-right), RL (right-left) */
+	direction: LayoutDirection;
+	/** Horizontal spacing between nodes */
+	nodeSpacing: number;
+	/** Vertical spacing between ranks/levels */
+	rankSpacing: number;
+}
+
+/**
+ * Default layout options.
+ */
+export const DEFAULT_LAYOUT_OPTIONS: QueryLayoutOptions = {
+	direction: 'TB',
+	nodeSpacing: 60,
+	rankSpacing: 80
+};
+
+/**
+ * Convert a parsed query to xyflow nodes and edges for visualization.
+ */
+export function layoutQueryVisualization(
+	parsedQuery: ParsedQueryVisual,
+	options: QueryLayoutOptions = DEFAULT_LAYOUT_OPTIONS
+): {
+	nodes: Node[];
+	edges: Edge[];
+} {
+	const nodes: Node[] = [];
+	const edges: Edge[] = [];
+	let nodeIndex = 0;
+
+	const createNodeId = (prefix: string) => `${prefix}-${nodeIndex++}`;
+
+	// Track the previous node to connect edges in the flow
+	let previousNodeId: string | null = null;
+
+	const connectToPrevious = (currentNodeId: string, label?: string) => {
+		if (previousNodeId) {
+			edges.push({
+				id: `edge-${previousNodeId}-${currentNodeId}`,
+				source: previousNodeId,
+				target: currentNodeId,
+				type: 'smoothstep',
+				animated: false,
+				style: 'stroke-width: 2px;',
+				...(label && { label, labelStyle: 'font-size: 10px; fill: #737373;' })
+			});
+		}
+		previousNodeId = currentNodeId;
+	};
+
+	// 1. Create source nodes (FROM tables)
+	// When we have JOINs, only create a source node for the FIRST table
+	// The joined tables will be created during JOIN processing
+	const sourceNodeIds: string[] = [];
+	const sourcesToCreate = parsedQuery.joins.length > 0
+		? parsedQuery.sources.slice(0, 1)  // Only first table when JOINs exist
+		: parsedQuery.sources;              // All tables when no JOINs
+
+	for (let i = 0; i < sourcesToCreate.length; i++) {
+		const source = sourcesToCreate[i];
+		const nodeId = createNodeId('source');
+		nodes.push({
+			id: nodeId,
+			type: 'tableSourceNode',
+			position: { x: 0, y: 0 },
+			data: {
+				source,
+				isFirst: i === 0 && parsedQuery.joins.length === 0
+			}
+		});
+		sourceNodeIds.push(nodeId);
+	}
+
+	// If no joins and single source, set it as the starting point
+	if (sourceNodeIds.length === 1 && parsedQuery.joins.length === 0) {
+		previousNodeId = sourceNodeIds[0];
+	}
+
+	// 2. Create JOIN nodes
+	// If we have JOINs, connect first source to first join, and create source nodes for joined tables
+	if (parsedQuery.joins.length > 0 && sourceNodeIds.length > 0) {
+		// Connect first source table
+		previousNodeId = sourceNodeIds[0];
+
+		for (let i = 0; i < parsedQuery.joins.length; i++) {
+			const join = parsedQuery.joins[i];
+
+			// Create a source node for the joined table (right side of join)
+			const joinedTableNodeId = createNodeId('source');
+			nodes.push({
+				id: joinedTableNodeId,
+				type: 'tableSourceNode',
+				position: { x: 0, y: 0 },
+				data: {
+					source: join.source,
+					isFirst: false
+				}
+			});
+
+			// Create the join node
+			const joinNodeId = createNodeId('join');
+			nodes.push({
+				id: joinNodeId,
+				type: 'joinNode',
+				position: { x: 0, y: 0 },
+				data: { join }
+			});
+
+			// Connect previous node (left side) to left input of join
+			if (previousNodeId) {
+				edges.push({
+					id: `edge-${previousNodeId}-${joinNodeId}-left`,
+					source: previousNodeId,
+					target: joinNodeId,
+					targetHandle: 'left',
+					type: 'smoothstep',
+					animated: false,
+					style: 'stroke-width: 2px;'
+				});
+			}
+
+			// Connect joined table (right side) to right input of join
+			edges.push({
+				id: `edge-${joinedTableNodeId}-${joinNodeId}-right`,
+				source: joinedTableNodeId,
+				target: joinNodeId,
+				targetHandle: 'right',
+				type: 'smoothstep',
+				animated: false,
+				style: 'stroke-width: 2px;'
+			});
+
+			previousNodeId = joinNodeId;
+		}
+	} else if (sourceNodeIds.length > 1) {
+		// Multiple sources without explicit JOINs (CROSS JOIN implied or comma-separated tables)
+		// Connect them sequentially
+		previousNodeId = sourceNodeIds[0];
+		for (let i = 1; i < sourceNodeIds.length; i++) {
+			edges.push({
+				id: `edge-${sourceNodeIds[i - 1]}-${sourceNodeIds[i]}`,
+				source: sourceNodeIds[i - 1],
+				target: sourceNodeIds[i],
+				type: 'smoothstep',
+				animated: false,
+				style: 'stroke-width: 2px;'
+			});
+			previousNodeId = sourceNodeIds[i];
+		}
+	}
+
+	// 3. Create WHERE filter node
+	if (parsedQuery.filters.length > 0) {
+		const filterNodeId = createNodeId('filter');
+		nodes.push({
+			id: filterNodeId,
+			type: 'filterNode',
+			position: { x: 0, y: 0 },
+			data: {
+				filter: parsedQuery.filters[0],
+				filterType: 'WHERE'
+			}
+		});
+		connectToPrevious(filterNodeId);
+	}
+
+	// 4. Create GROUP BY node
+	if (parsedQuery.groupBy && parsedQuery.groupBy.length > 0) {
+		const groupNodeId = createNodeId('group');
+		nodes.push({
+			id: groupNodeId,
+			type: 'groupNode',
+			position: { x: 0, y: 0 },
+			data: { columns: parsedQuery.groupBy }
+		});
+		connectToPrevious(groupNodeId);
+	}
+
+	// 5. Create HAVING filter node
+	if (parsedQuery.having) {
+		const havingNodeId = createNodeId('having');
+		nodes.push({
+			id: havingNodeId,
+			type: 'filterNode',
+			position: { x: 0, y: 0 },
+			data: {
+				filter: parsedQuery.having,
+				filterType: 'HAVING'
+			}
+		});
+		connectToPrevious(havingNodeId);
+	}
+
+	// 6. Create SELECT/projection node
+	if (parsedQuery.projections.length > 0) {
+		const projectionNodeId = createNodeId('projection');
+		nodes.push({
+			id: projectionNodeId,
+			type: 'projectionNode',
+			position: { x: 0, y: 0 },
+			data: {
+				projections: parsedQuery.projections,
+				distinct: parsedQuery.distinct
+			}
+		});
+		connectToPrevious(projectionNodeId);
+	}
+
+	// 7. Create ORDER BY node
+	if (parsedQuery.orderBy.length > 0) {
+		const sortNodeId = createNodeId('sort');
+		nodes.push({
+			id: sortNodeId,
+			type: 'sortNode',
+			position: { x: 0, y: 0 },
+			data: { orderBy: parsedQuery.orderBy }
+		});
+		connectToPrevious(sortNodeId);
+	}
+
+	// 8. Create LIMIT node
+	if (parsedQuery.limit) {
+		const limitNodeId = createNodeId('limit');
+		nodes.push({
+			id: limitNodeId,
+			type: 'limitNode',
+			position: { x: 0, y: 0 },
+			data: { limit: parsedQuery.limit }
+		});
+		connectToPrevious(limitNodeId);
+	}
+
+	// Apply dagre layout
+	const layoutedNodes = applyDagreLayout(nodes, edges, options);
+
+	return { nodes: layoutedNodes, edges };
+}
+
+/**
+ * Apply dagre layout to position nodes automatically.
+ */
+function applyDagreLayout(nodes: Node[], edges: Edge[], options: QueryLayoutOptions): Node[] {
+	if (nodes.length === 0) return [];
+
+	const dagreGraph = new dagre.graphlib.Graph();
+	dagreGraph.setDefaultEdgeLabel(() => ({}));
+	dagreGraph.setGraph({
+		rankdir: options.direction,
+		nodesep: options.nodeSpacing,
+		ranksep: options.rankSpacing,
+		marginx: 40,
+		marginy: 40,
+		align: 'UL'
+	});
+
+	// Determine source/target positions based on direction
+	const isHorizontal = options.direction === 'LR' || options.direction === 'RL';
+	const targetPos = isHorizontal
+		? (options.direction === 'LR' ? Position.Left : Position.Right)
+		: (options.direction === 'TB' ? Position.Top : Position.Bottom);
+	const sourcePos = isHorizontal
+		? (options.direction === 'LR' ? Position.Right : Position.Left)
+		: (options.direction === 'TB' ? Position.Bottom : Position.Top);
+
+	// Add nodes to dagre
+	for (const node of nodes) {
+		dagreGraph.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+	}
+
+	// Add edges to dagre
+	for (const edge of edges) {
+		dagreGraph.setEdge(edge.source, edge.target);
+	}
+
+	// Calculate layout
+	dagre.layout(dagreGraph);
+
+	// Get positions from dagre
+	const positionedNodes = nodes.map((node) => {
+		const nodeWithPosition = dagreGraph.node(node.id);
+		return {
+			...node,
+			targetPosition: targetPos,
+			sourcePosition: sourcePos,
+			position: {
+				x: nodeWithPosition.x - NODE_WIDTH / 2,
+				y: nodeWithPosition.y - NODE_HEIGHT / 2
+			}
+		};
+	});
+
+	// Center the graph horizontally
+	// Find the bounding box
+	let minX = Infinity;
+	let maxX = -Infinity;
+	for (const node of positionedNodes) {
+		minX = Math.min(minX, node.position.x);
+		maxX = Math.max(maxX, node.position.x + NODE_WIDTH);
+	}
+
+	// Calculate offset to center around x=0
+	const graphWidth = maxX - minX;
+	const offsetX = -minX - graphWidth / 2 + NODE_WIDTH / 2;
+
+	// Apply centering offset
+	return positionedNodes.map((node) => ({
+		...node,
+		position: {
+			x: node.position.x + offsetX,
+			y: node.position.y
+		}
+	}));
+}


### PR DESCRIPTION
## Summary
- Adds a visual query explainer that displays SQL query structure using the existing @xyflow/svelte canvas
- Shows tables, JOINs, filters, GROUP BY, ORDER BY, and aggregations as a data flow diagram
- Accessible via "Visualize Query" option in the query editor's execute dropdown menu

## Features
- **SQL Parsing**: Uses `node-sql-parser` to extract query structure (tables, joins, filters, GROUP BY, projections, ORDER BY, LIMIT)
- **Visual Nodes**: Color-coded nodes for different SQL components:
  - Blue: Table sources
  - Violet/Amber/Orange: JOINs (color by type)
  - Orange: WHERE/HAVING filters
  - Teal: GROUP BY
  - Gray: SELECT projections (green indicators for aggregates)
  - Indigo: ORDER BY
  - Pink: LIMIT
- **Layout Options**: Configurable direction (TB/BT/LR/RL), node spacing, and level spacing
- **Export**: PNG export support

## Test plan
- [ ] Write a SQL query with JOINs in query editor
- [ ] Click Execute dropdown → "Visualize Query"
- [ ] Verify all tables and JOINs are properly connected
- [ ] Test layout direction changes (TB, LR, etc.)
- [ ] Test spacing adjustments
- [ ] Export to PNG

🤖 Generated with [Claude Code](https://claude.ai/code)