### PR TITLE
Add embedded EXPLAIN and visualize results in query tabs

### DIFF
--- a/src/lib/components/charts/chart-config-popover.svelte
+++ b/src/lib/components/charts/chart-config-popover.svelte
@@ -60,9 +60,9 @@
 
 <Popover bind:open>
 	<PopoverTrigger>
-		<Button variant="ghost" size="sm" class="h-7 gap-1.5">
+		<Button variant="ghost" size="sm" class="h-7 gap-1.5 px-2">
 			<SettingsIcon class="size-3.5" />
-			<span class="text-xs">Configure</span>
+			Configure
 		</Button>
 	</PopoverTrigger>
 	<PopoverContent class="w-72" align="end">

--- a/src/lib/components/query-editor/explain-result-pane.svelte
+++ b/src/lib/components/query-editor/explain-result-pane.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import { SvelteFlow, Background, Controls, MiniMap } from "@xyflow/svelte";
+	import "@xyflow/svelte/dist/style.css";
+	import { LoaderIcon, DatabaseIcon } from "@lucide/svelte";
+	import ExplainPlanNode from "$lib/components/explain-plan-node.svelte";
+	import { layoutExplainPlan } from "$lib/utils/explain-layout";
+	import type { Node, Edge, NodeTypes, ColorMode } from "@xyflow/svelte";
+	import type { EmbeddedExplainResult } from "$lib/types";
+	import { mode } from "mode-watcher";
+	import { m } from "$lib/paraglide/messages.js";
+
+	type Props = {
+		explainResult: EmbeddedExplainResult;
+	};
+
+	let { explainResult }: Props = $props();
+
+	// Map mode-watcher theme to xyflow colorMode
+	const colorMode: ColorMode = $derived(mode.current === "dark" ? "dark" : "light");
+
+	// Custom node types
+	const nodeTypes: NodeTypes = {
+		planNode: ExplainPlanNode,
+	};
+
+	// Convert explain result to xyflow nodes and edges
+	const flowData = $derived.by(() => {
+		if (!explainResult.result) {
+			return { nodes: [] as Node[], edges: [] as Edge[] };
+		}
+		return layoutExplainPlan(explainResult.result);
+	});
+
+	let nodes = $derived(flowData.nodes);
+	let edges = $derived(flowData.edges);
+</script>
+
+<div class="flex-1 min-h-0">
+	{#if explainResult.isExecuting}
+		<!-- Loading state -->
+		<div class="h-full flex items-center justify-center">
+			<div class="flex flex-col items-center gap-3">
+				<LoaderIcon class="size-8 animate-spin text-muted-foreground" />
+				<p class="text-sm text-muted-foreground">{m.explain_analyzing()}</p>
+			</div>
+		</div>
+	{:else if explainResult.result}
+		<!-- Flow Diagram -->
+		<SvelteFlow
+			{nodes}
+			{edges}
+			{nodeTypes}
+			{colorMode}
+			fitView
+			minZoom={0.1}
+			maxZoom={2}
+			nodesDraggable={true}
+			nodesConnectable={false}
+			elementsSelectable={true}
+			proOptions={{ hideAttribution: true }}
+		>
+			<Background />
+			<Controls />
+			<MiniMap />
+		</SvelteFlow>
+	{:else}
+		<!-- Empty state -->
+		<div class="h-full flex items-center justify-center text-muted-foreground">
+			<div class="text-center">
+				<DatabaseIcon class="size-12 mx-auto mb-2 opacity-20" />
+				<p class="text-sm">{m.explain_no_plan_available()}</p>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/query-editor/index.ts
+++ b/src/lib/components/query-editor/index.ts
@@ -4,3 +4,5 @@ export { default as QueryExportMenu } from './query-export-menu.svelte';
 export { default as QueryPagination } from './query-pagination.svelte';
 export { default as QueryErrorDisplay } from './query-error-display.svelte';
 export { default as QueryResultViewToggle } from './query-result-view-toggle.svelte';
+export { default as ExplainResultPane } from './explain-result-pane.svelte';
+export { default as VisualizeResultPane } from './visualize-result-pane.svelte';

--- a/src/lib/components/query-editor/query-export-menu.svelte
+++ b/src/lib/components/query-editor/query-export-menu.svelte
@@ -13,18 +13,17 @@
 	let { onExport, onCopy }: Props = $props();
 </script>
 
-<div class="flex items-center justify-end p-2 border-b bg-muted/30 shrink-0">
-	<DropdownMenu.Root>
-		<DropdownMenu.Trigger
-			class={buttonVariants({
-				variant: "outline",
-				size: "sm"
-			}) + " h-7 gap-1"}
-		>
-			<DownloadIcon class="size-3" />
-			{m.query_export()}
-			<ChevronDownIcon class="size-3" />
-		</DropdownMenu.Trigger>
+<DropdownMenu.Root>
+	<DropdownMenu.Trigger
+		class={buttonVariants({
+			variant: "ghost",
+			size: "sm"
+		}) + " h-7 gap-1.5 px-2"}
+	>
+		<DownloadIcon class="size-3.5" />
+		{m.query_export()}
+		<ChevronDownIcon class="size-3" />
+	</DropdownMenu.Trigger>
 		<DropdownMenu.Content align="end" class="w-48">
 			<DropdownMenu.Group>
 				<DropdownMenu.GroupHeading>{m.query_download()}</DropdownMenu.GroupHeading>
@@ -66,5 +65,4 @@
 				</DropdownMenu.Item>
 			</DropdownMenu.Group>
 		</DropdownMenu.Content>
-	</DropdownMenu.Root>
-</div>
+</DropdownMenu.Root>

--- a/src/lib/components/query-editor/query-result-view-toggle.svelte
+++ b/src/lib/components/query-editor/query-result-view-toggle.svelte
@@ -1,14 +1,26 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { TableIcon, BarChart3Icon } from '@lucide/svelte';
+	import { Badge } from '$lib/components/ui/badge';
+	import { TableIcon, BarChart3Icon, DatabaseIcon, NetworkIcon } from '@lucide/svelte';
 	import type { ResultViewMode } from '$lib/types';
 
 	type Props = {
 		mode: ResultViewMode;
 		onModeChange: (mode: ResultViewMode) => void;
+		hasExplainResult?: boolean;
+		hasVisualizeResult?: boolean;
+		isExplainStale?: boolean;
+		isVisualizeStale?: boolean;
 	};
 
-	let { mode, onModeChange }: Props = $props();
+	let {
+		mode,
+		onModeChange,
+		hasExplainResult = false,
+		hasVisualizeResult = false,
+		isExplainStale = false,
+		isVisualizeStale = false
+	}: Props = $props();
 </script>
 
 <div class="flex items-center gap-0.5 rounded-md border bg-muted/50 p-0.5">
@@ -30,4 +42,36 @@
 		<BarChart3Icon class="size-3" />
 		<span class="text-xs">Chart</span>
 	</Button>
+	{#if hasExplainResult}
+		<Button
+			variant={mode === 'explain' ? 'default' : 'ghost'}
+			size="sm"
+			class="h-6 gap-1 px-2"
+			onclick={() => onModeChange('explain')}
+		>
+			<DatabaseIcon class="size-3" />
+			<span class="text-xs">Explain</span>
+			{#if isExplainStale}
+				<Badge variant="outline" class="h-4 px-1 text-[10px] text-amber-500 border-amber-500/50">
+					Changed
+				</Badge>
+			{/if}
+		</Button>
+	{/if}
+	{#if hasVisualizeResult}
+		<Button
+			variant={mode === 'visualize' ? 'default' : 'ghost'}
+			size="sm"
+			class="h-6 gap-1 px-2"
+			onclick={() => onModeChange('visualize')}
+		>
+			<NetworkIcon class="size-3" />
+			<span class="text-xs">Visual</span>
+			{#if isVisualizeStale}
+				<Badge variant="outline" class="h-4 px-1 text-[10px] text-amber-500 border-amber-500/50">
+					Changed
+				</Badge>
+			{/if}
+		</Button>
+	{/if}
 </div>

--- a/src/lib/components/query-editor/visualize-result-pane.svelte
+++ b/src/lib/components/query-editor/visualize-result-pane.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import { SvelteFlow, Background, Controls, MiniMap } from "@xyflow/svelte";
+	import "@xyflow/svelte/dist/style.css";
+	import { AlertCircleIcon, NetworkIcon } from "@lucide/svelte";
+	import {
+		TableSourceNode,
+		JoinNode,
+		FilterNode,
+		GroupNode,
+		ProjectionNode,
+		SortNode,
+		LimitNode
+	} from "$lib/components/query-visual/nodes";
+	import { layoutQueryVisualization, type QueryLayoutOptions } from "$lib/utils/query-visual-layout";
+	import type { Node, Edge, NodeTypes, ColorMode } from "@xyflow/svelte";
+	import type { EmbeddedVisualizeResult } from "$lib/types";
+	import { mode } from "mode-watcher";
+
+	type Props = {
+		visualizeResult: EmbeddedVisualizeResult;
+		layoutOptions: QueryLayoutOptions;
+	};
+
+	let { visualizeResult, layoutOptions }: Props = $props();
+
+	// Map mode-watcher theme to xyflow colorMode
+	const colorMode: ColorMode = $derived(mode.current === "dark" ? "dark" : "light");
+
+	// Custom node types
+	const nodeTypes: NodeTypes = {
+		tableSourceNode: TableSourceNode,
+		joinNode: JoinNode,
+		filterNode: FilterNode,
+		groupNode: GroupNode,
+		projectionNode: ProjectionNode,
+		sortNode: SortNode,
+		limitNode: LimitNode
+	};
+
+	// Compute flow data from visualize result
+	const flowData = $derived.by(() => {
+		if (!visualizeResult.parsedQuery) {
+			return { nodes: [] as Node[], edges: [] as Edge[] };
+		}
+		return layoutQueryVisualization(visualizeResult.parsedQuery, layoutOptions);
+	});
+
+	let nodes = $derived(flowData.nodes);
+	let edges = $derived(flowData.edges);
+</script>
+
+<div class="flex-1 min-h-0">
+	{#if visualizeResult.parsedQuery}
+		<!-- Flow Diagram -->
+		{#if nodes.length > 0}
+			<SvelteFlow
+				{nodes}
+				{edges}
+				{nodeTypes}
+				{colorMode}
+				fitView
+				minZoom={0.1}
+				maxZoom={2}
+				nodesDraggable={true}
+				nodesConnectable={false}
+				elementsSelectable={true}
+				deleteKey={null}
+				proOptions={{ hideAttribution: true }}
+			>
+				<Background />
+				<Controls />
+				<MiniMap />
+			</SvelteFlow>
+		{:else}
+			<div class="h-full flex items-center justify-center text-muted-foreground">
+				<div class="text-center">
+					<NetworkIcon class="size-12 mx-auto mb-2 opacity-20" />
+					<p class="text-sm">Unable to visualize query structure</p>
+				</div>
+			</div>
+		{/if}
+	{:else if visualizeResult.parseError}
+		<!-- Parse error state -->
+		<div class="h-full flex items-center justify-center text-muted-foreground p-4">
+			<div class="text-center max-w-md">
+				<AlertCircleIcon class="size-12 mx-auto mb-4 text-destructive opacity-50" />
+				<h3 class="text-lg font-semibold mb-2">Could not parse query</h3>
+				<p class="text-sm mb-4">{visualizeResult.parseError}</p>
+				<div class="bg-muted p-3 rounded-md">
+					<code class="text-xs font-mono break-all text-left block">
+						{visualizeResult.sourceQuery}
+					</code>
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/hooks/database.svelte.ts
+++ b/src/lib/hooks/database.svelte.ts
@@ -148,6 +148,23 @@ class UseDatabase {
       this.starterTabs.initializeDefaults(projectId);
     });
 
+    // Set up embedded explain callbacks
+    this.explainTabs.setEmbeddedCallbacks(
+      (tabId, result, sourceQuery, isAnalyze) => {
+        this.queryTabs.setExplainResult(tabId, result, sourceQuery, isAnalyze);
+      },
+      (tabId, isExecuting, isAnalyze) => {
+        this.queryTabs.setExplainExecuting(tabId, isExecuting, isAnalyze);
+      }
+    );
+
+    // Set up embedded visualize callback
+    this.visualizeTabs.setEmbeddedCallback(
+      (tabId, parsedQuery, sourceQuery, parseError) => {
+        this.queryTabs.setVisualizeResult(tabId, parsedQuery, sourceQuery, parseError);
+      }
+    );
+
     // Initialize: projects first, then connections
     this.initializeApp();
   }

--- a/src/lib/hooks/database/query-tabs.svelte.ts
+++ b/src/lib/hooks/database/query-tabs.svelte.ts
@@ -1,4 +1,4 @@
-import type { QueryTab } from '$lib/types';
+import type { QueryTab, ExplainResult, ParsedQueryVisual } from '$lib/types';
 import type { DatabaseState } from './state.svelte.js';
 import type { TabOrderingManager } from './tab-ordering.svelte.js';
 
@@ -220,5 +220,118 @@ export class QueryTabManager {
 			this.add(`History: ${item.query.substring(0, 20)}...`, item.query);
 			setActiveView?.();
 		}
+	}
+
+	/**
+	 * Set the explain result on a query tab.
+	 */
+	setExplainResult(tabId: string, result: ExplainResult, sourceQuery: string, isAnalyze: boolean): void {
+		if (!this.state.activeProjectId) return;
+
+		const projectId = this.state.activeProjectId;
+		const tabs = this.state.queryTabsByProject[projectId] ?? [];
+		const updatedTabs = tabs.map((t) =>
+			t.id === tabId
+				? {
+						...t,
+						explainResult: { result, sourceQuery, isAnalyze, isExecuting: false }
+					}
+				: t
+		);
+		this.state.queryTabsByProject = {
+			...this.state.queryTabsByProject,
+			[projectId]: updatedTabs
+		};
+		this.schedulePersistence(projectId);
+	}
+
+	/**
+	 * Set the explain executing state on a query tab.
+	 */
+	setExplainExecuting(tabId: string, isExecuting: boolean, isAnalyze: boolean = false): void {
+		if (!this.state.activeProjectId) return;
+
+		const projectId = this.state.activeProjectId;
+		const tabs = this.state.queryTabsByProject[projectId] ?? [];
+		const tab = tabs.find((t) => t.id === tabId);
+
+		const updatedTabs = tabs.map((t) =>
+			t.id === tabId
+				? {
+						...t,
+						explainResult: t.explainResult
+							? { ...t.explainResult, isExecuting }
+							: { result: undefined as unknown as ExplainResult, sourceQuery: '', isAnalyze, isExecuting }
+					}
+				: t
+		);
+		this.state.queryTabsByProject = {
+			...this.state.queryTabsByProject,
+			[projectId]: updatedTabs
+		};
+	}
+
+	/**
+	 * Clear the explain result from a query tab.
+	 */
+	clearExplainResult(tabId: string): void {
+		if (!this.state.activeProjectId) return;
+
+		const projectId = this.state.activeProjectId;
+		const tabs = this.state.queryTabsByProject[projectId] ?? [];
+		const updatedTabs = tabs.map((t) =>
+			t.id === tabId ? { ...t, explainResult: undefined } : t
+		);
+		this.state.queryTabsByProject = {
+			...this.state.queryTabsByProject,
+			[projectId]: updatedTabs
+		};
+		this.schedulePersistence(projectId);
+	}
+
+	/**
+	 * Set the visualize result on a query tab.
+	 */
+	setVisualizeResult(
+		tabId: string,
+		parsedQuery: ParsedQueryVisual | null,
+		sourceQuery: string,
+		parseError?: string
+	): void {
+		if (!this.state.activeProjectId) return;
+
+		const projectId = this.state.activeProjectId;
+		const tabs = this.state.queryTabsByProject[projectId] ?? [];
+		const updatedTabs = tabs.map((t) =>
+			t.id === tabId
+				? {
+						...t,
+						visualizeResult: { parsedQuery, sourceQuery, parseError }
+					}
+				: t
+		);
+		this.state.queryTabsByProject = {
+			...this.state.queryTabsByProject,
+			[projectId]: updatedTabs
+		};
+		this.schedulePersistence(projectId);
+	}
+
+	/**
+	 * Clear the visualize result from a query tab.
+	 */
+	clearVisualizeResult(tabId: string): void {
+		if (!this.state.activeProjectId) return;
+
+		const projectId = this.state.activeProjectId;
+		const tabs = this.state.queryTabsByProject[projectId] ?? [];
+		const updatedTabs = tabs.map((t) =>
+			t.id === tabId ? { ...t, visualizeResult: undefined } : t
+		);
+		this.state.queryTabsByProject = {
+			...this.state.queryTabsByProject,
+			[projectId]: updatedTabs
+		};
+		this.schedulePersistence(projectId);
 	}
 }

--- a/src/lib/types/chart.ts
+++ b/src/lib/types/chart.ts
@@ -25,4 +25,4 @@ export interface ChartConfig {
 /**
  * View mode for displaying query results.
  */
-export type ResultViewMode = 'table' | 'chart';
+export type ResultViewMode = 'table' | 'chart' | 'explain' | 'visualize';

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -28,6 +28,8 @@ export type {
 	SourceTableInfo,
 	QueryResult,
 	StatementResult,
+	EmbeddedExplainResult,
+	EmbeddedVisualizeResult,
 	QueryTab,
 	QueryHistoryItem,
 	SavedQuery,

--- a/src/lib/types/query.ts
+++ b/src/lib/types/query.ts
@@ -5,6 +5,8 @@
 
 import type { QueryType } from '../db/query-utils';
 import type { ConnectionLabel } from './project';
+import type { ExplainResult } from './explain';
+import type { ParsedQueryVisual } from './visualize';
 
 /**
  * Supported data types for query parameters.
@@ -95,6 +97,32 @@ export interface StatementResult extends QueryResult {
 }
 
 /**
+ * Embedded explain result within a query tab.
+ */
+export interface EmbeddedExplainResult {
+	/** The explain result data */
+	result: ExplainResult;
+	/** The query that was explained (for staleness detection) */
+	sourceQuery: string;
+	/** Whether this was EXPLAIN ANALYZE vs plain EXPLAIN */
+	isAnalyze: boolean;
+	/** Whether the explain is currently executing */
+	isExecuting: boolean;
+}
+
+/**
+ * Embedded visualize result within a query tab.
+ */
+export interface EmbeddedVisualizeResult {
+	/** Parsed query structure for visualization */
+	parsedQuery: ParsedQueryVisual | null;
+	/** The query that was visualized (for staleness detection) */
+	sourceQuery: string;
+	/** Error message if parsing failed */
+	parseError?: string;
+}
+
+/**
  * Represents an open query editor tab.
  */
 export interface QueryTab {
@@ -112,6 +140,10 @@ export interface QueryTab {
 	isExecuting: boolean;
 	/** ID of the saved query this tab was loaded from, if any */
 	savedQueryId?: string;
+	/** Embedded explain result displayed below the editor */
+	explainResult?: EmbeddedExplainResult;
+	/** Embedded visualize result displayed below the editor */
+	visualizeResult?: EmbeddedVisualizeResult;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds inline EXPLAIN results visualization within query tabs
- Adds inline query structure visualization within query tabs  
- New toggle controls to show/hide explain and visualize panes
- State management for embedded results with staleness detection

## Test plan
- [ ] Run EXPLAIN on a query and verify the plan is displayed inline
- [ ] Toggle explain pane visibility using the view controls
- [ ] Verify visualize pane shows parsed query structure
- [ ] Test staleness detection when query changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)