### PR TITLE
Always show Explain and Visualize tabs with empty states

### DIFF
--- a/src/lib/components/query-editor/query-result-view-toggle.svelte
+++ b/src/lib/components/query-editor/query-result-view-toggle.svelte
@@ -42,36 +42,32 @@
 		<BarChart3Icon class="size-3" />
 		<span class="text-xs">Chart</span>
 	</Button>
-	{#if hasExplainResult}
-		<Button
-			variant={mode === 'explain' ? 'default' : 'ghost'}
-			size="sm"
-			class="h-6 gap-1 px-2"
-			onclick={() => onModeChange('explain')}
-		>
-			<DatabaseIcon class="size-3" />
-			<span class="text-xs">Explain</span>
-			{#if isExplainStale}
-				<Badge variant="outline" class="h-4 px-1 text-[10px] text-amber-500 border-amber-500/50">
-					Changed
-				</Badge>
-			{/if}
-		</Button>
-	{/if}
-	{#if hasVisualizeResult}
-		<Button
-			variant={mode === 'visualize' ? 'default' : 'ghost'}
-			size="sm"
-			class="h-6 gap-1 px-2"
-			onclick={() => onModeChange('visualize')}
-		>
-			<NetworkIcon class="size-3" />
-			<span class="text-xs">Visual</span>
-			{#if isVisualizeStale}
-				<Badge variant="outline" class="h-4 px-1 text-[10px] text-amber-500 border-amber-500/50">
-					Changed
-				</Badge>
-			{/if}
-		</Button>
-	{/if}
+	<Button
+		variant={mode === 'explain' ? 'default' : 'ghost'}
+		size="sm"
+		class="h-6 gap-1 px-2"
+		onclick={() => onModeChange('explain')}
+	>
+		<DatabaseIcon class="size-3" />
+		<span class="text-xs">Explain</span>
+		{#if hasExplainResult && isExplainStale}
+			<Badge variant="outline" class="h-4 px-1 text-[10px] text-amber-500 border-amber-500/50">
+				Changed
+			</Badge>
+		{/if}
+	</Button>
+	<Button
+		variant={mode === 'visualize' ? 'default' : 'ghost'}
+		size="sm"
+		class="h-6 gap-1 px-2"
+		onclick={() => onModeChange('visualize')}
+	>
+		<NetworkIcon class="size-3" />
+		<span class="text-xs">Visual</span>
+		{#if hasVisualizeResult && isVisualizeStale}
+			<Badge variant="outline" class="h-4 px-1 text-[10px] text-amber-500 border-amber-500/50">
+				Changed
+			</Badge>
+		{/if}
+	</Button>
 </div>

--- a/src/lib/components/query-visual/nodes/filter-node.svelte
+++ b/src/lib/components/query-visual/nodes/filter-node.svelte
@@ -8,15 +8,17 @@
 			filter: QueryFilter;
 			filterType: 'WHERE' | 'HAVING';
 		};
+		sourcePosition?: Position;
+		targetPosition?: Position;
 	};
 
-	let { data }: Props = $props();
+	let { data, sourcePosition = Position.Bottom, targetPosition = Position.Top }: Props = $props();
 </script>
 
 <div
 	class="min-w-48 rounded-lg border-2 border-orange-500 bg-background shadow-md"
 >
-	<Handle type="target" position={Position.Top} class="!bg-orange-500" />
+	<Handle type="target" position={targetPosition} class="!bg-orange-500" />
 
 	<div class="flex items-center gap-2 px-3 py-2 bg-orange-500/10 border-b border-orange-500/20 rounded-t-md">
 		<FilterIcon class="size-4 text-orange-500" />
@@ -30,5 +32,5 @@
 		</div>
 	</div>
 
-	<Handle type="source" position={Position.Bottom} class="!bg-orange-500" />
+	<Handle type="source" position={sourcePosition} class="!bg-orange-500" />
 </div>

--- a/src/lib/components/query-visual/nodes/group-node.svelte
+++ b/src/lib/components/query-visual/nodes/group-node.svelte
@@ -6,15 +6,17 @@
 		data: {
 			columns: string[];
 		};
+		sourcePosition?: Position;
+		targetPosition?: Position;
 	};
 
-	let { data }: Props = $props();
+	let { data, sourcePosition = Position.Bottom, targetPosition = Position.Top }: Props = $props();
 </script>
 
 <div
 	class="min-w-40 rounded-lg border-2 border-teal-500 bg-background shadow-md"
 >
-	<Handle type="target" position={Position.Top} class="!bg-teal-500" />
+	<Handle type="target" position={targetPosition} class="!bg-teal-500" />
 
 	<div class="flex items-center gap-2 px-3 py-2 bg-teal-500/10 border-b border-teal-500/20 rounded-t-md">
 		<GroupIcon class="size-4 text-teal-500" />
@@ -30,5 +32,5 @@
 		{/each}
 	</div>
 
-	<Handle type="source" position={Position.Bottom} class="!bg-teal-500" />
+	<Handle type="source" position={sourcePosition} class="!bg-teal-500" />
 </div>

--- a/src/lib/components/query-visual/nodes/join-node.svelte
+++ b/src/lib/components/query-visual/nodes/join-node.svelte
@@ -7,9 +7,16 @@
 		data: {
 			join: QueryJoin;
 		};
+		sourcePosition?: Position;
+		targetPosition?: Position;
 	};
 
-	let { data }: Props = $props();
+	let { data, sourcePosition = Position.Bottom, targetPosition = Position.Top }: Props = $props();
+
+	// For horizontal layouts, the offset should be vertical (top %), for vertical layouts it's horizontal (left %)
+	const isHorizontal = $derived(targetPosition === Position.Left || targetPosition === Position.Right);
+	const leftHandleStyle = $derived(isHorizontal ? "top: 30%;" : "left: 30%;");
+	const rightHandleStyle = $derived(isHorizontal ? "top: 70%;" : "left: 70%;");
 
 	const joinColors: Record<string, { border: string; bg: string; text: string }> = {
 		INNER: { border: 'border-violet-500', bg: 'bg-violet-500/10', text: 'text-violet-500' },
@@ -24,8 +31,8 @@
 
 <div class="min-w-48 rounded-lg border-2 bg-background shadow-md {colors.border}">
 	<!-- Input handles (left side for sources) -->
-	<Handle type="target" position={Position.Top} id="left" style="left: 30%;" class="!bg-violet-500" />
-	<Handle type="target" position={Position.Top} id="right" style="left: 70%;" class="!bg-violet-500" />
+	<Handle type="target" position={targetPosition} id="left" style={leftHandleStyle} class="!bg-violet-500" />
+	<Handle type="target" position={targetPosition} id="right" style={rightHandleStyle} class="!bg-violet-500" />
 
 	<div class="flex items-center gap-2 px-3 py-2 border-b rounded-t-md {colors.bg}">
 		<MergeIcon class="size-4 {colors.text}" />
@@ -53,5 +60,5 @@
 	</div>
 
 	<!-- Output handle -->
-	<Handle type="source" position={Position.Bottom} class="!bg-violet-500" />
+	<Handle type="source" position={sourcePosition} class="!bg-violet-500" />
 </div>

--- a/src/lib/components/query-visual/nodes/limit-node.svelte
+++ b/src/lib/components/query-visual/nodes/limit-node.svelte
@@ -6,15 +6,16 @@
 		data: {
 			limit: { count: number; offset?: number };
 		};
+		targetPosition?: Position;
 	};
 
-	let { data }: Props = $props();
+	let { data, targetPosition = Position.Top }: Props = $props();
 </script>
 
 <div
 	class="min-w-32 rounded-lg border-2 border-pink-500 bg-background shadow-md"
 >
-	<Handle type="target" position={Position.Top} class="!bg-pink-500" />
+	<Handle type="target" position={targetPosition} class="!bg-pink-500" />
 
 	<div class="flex items-center gap-2 px-3 py-2 bg-pink-500/10 border-b border-pink-500/20 rounded-t-md">
 		<ListEndIcon class="size-4 text-pink-500" />

--- a/src/lib/components/query-visual/nodes/projection-node.svelte
+++ b/src/lib/components/query-visual/nodes/projection-node.svelte
@@ -8,9 +8,11 @@
 			projections: QueryProjection[];
 			distinct: boolean;
 		};
+		sourcePosition?: Position;
+		targetPosition?: Position;
 	};
 
-	let { data }: Props = $props();
+	let { data, sourcePosition = Position.Bottom, targetPosition = Position.Top }: Props = $props();
 
 	const maxDisplayed = 8;
 	const displayedProjections = $derived(data.projections.slice(0, maxDisplayed));
@@ -20,7 +22,7 @@
 <div
 	class="min-w-48 rounded-lg border-2 border-slate-500 bg-background shadow-md"
 >
-	<Handle type="target" position={Position.Top} class="!bg-slate-500" />
+	<Handle type="target" position={targetPosition} class="!bg-slate-500" />
 
 	<div class="flex items-center gap-2 px-3 py-2 bg-slate-500/10 border-b border-slate-500/20 rounded-t-md">
 		<ListIcon class="size-4 text-slate-500" />
@@ -57,5 +59,5 @@
 		{/if}
 	</div>
 
-	<Handle type="source" position={Position.Bottom} class="!bg-slate-500" />
+	<Handle type="source" position={sourcePosition} class="!bg-slate-500" />
 </div>

--- a/src/lib/components/query-visual/nodes/sort-node.svelte
+++ b/src/lib/components/query-visual/nodes/sort-node.svelte
@@ -7,15 +7,17 @@
 		data: {
 			orderBy: QueryOrderBy[];
 		};
+		sourcePosition?: Position;
+		targetPosition?: Position;
 	};
 
-	let { data }: Props = $props();
+	let { data, sourcePosition = Position.Bottom, targetPosition = Position.Top }: Props = $props();
 </script>
 
 <div
 	class="min-w-40 rounded-lg border-2 border-indigo-500 bg-background shadow-md"
 >
-	<Handle type="target" position={Position.Top} class="!bg-indigo-500" />
+	<Handle type="target" position={targetPosition} class="!bg-indigo-500" />
 
 	<div class="flex items-center gap-2 px-3 py-2 bg-indigo-500/10 border-b border-indigo-500/20 rounded-t-md">
 		<ArrowUpDownIcon class="size-4 text-indigo-500" />
@@ -39,5 +41,5 @@
 		{/each}
 	</div>
 
-	<Handle type="source" position={Position.Bottom} class="!bg-indigo-500" />
+	<Handle type="source" position={sourcePosition} class="!bg-indigo-500" />
 </div>

--- a/src/lib/components/query-visual/nodes/table-source-node.svelte
+++ b/src/lib/components/query-visual/nodes/table-source-node.svelte
@@ -8,9 +8,11 @@
 			source: QuerySource;
 			isFirst: boolean;
 		};
+		sourcePosition?: Position;
+		targetPosition?: Position;
 	};
 
-	let { data }: Props = $props();
+	let { data, sourcePosition = Position.Bottom, targetPosition = Position.Top }: Props = $props();
 </script>
 
 <div
@@ -41,10 +43,10 @@
 	</div>
 
 	<!-- Output handle for connecting to next node -->
-	<Handle type="source" position={Position.Bottom} class="!bg-blue-500" />
+	<Handle type="source" position={sourcePosition} class="!bg-blue-500" />
 
 	<!-- Input handle if not first node -->
 	{#if !data.isFirst}
-		<Handle type="target" position={Position.Top} class="!bg-blue-500" />
+		<Handle type="target" position={targetPosition} class="!bg-blue-500" />
 	{/if}
 </div>


### PR DESCRIPTION
## Summary
- Show Explain and Visualize tabs in the view toggle permanently instead of only when results exist
- Add helpful empty state UI with quick action buttons (Explain, Explain Analyze, Visualize Query) when no results are available
- Improve SQL statement offset detection to return the last statement when cursor is positioned after all statements

## Test plan
- [ ] Verify Explain and Visualize tabs are visible even with no query results
- [ ] Click on Explain tab with no results and confirm empty state with action buttons appears
- [ ] Click on Visualize tab with no results and confirm empty state with action button appears
- [ ] Run explain/visualize from empty state buttons and verify results display correctly
- [ ] Test cursor positioning after last statement selects the correct statement

🤖 Generated with [Claude Code](https://claude.com/claude-code)