### PR TITLE
Add Windows build targets to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,12 @@ jobs:
           - platform: "ubuntu-24.04-arm" # for Linux ARM64
             args: "--target aarch64-unknown-linux-gnu"
             target: aarch64-unknown-linux-gnu
+          - platform: "windows-latest" # for Windows x86_64
+            args: "--target x86_64-pc-windows-msvc"
+            target: x86_64-pc-windows-msvc
+          - platform: "windows-latest" # for Windows ARM64
+            args: "--target aarch64-pc-windows-msvc"
+            target: aarch64-pc-windows-msvc
 
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
## Summary
- Adds Windows x86_64 and ARM64 build targets to the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)