### PR TITLE
Fix all svelte-check warnings

### DIFF
--- a/src/lib/components/canvas/nodes/query-node.svelte
+++ b/src/lib/components/canvas/nodes/query-node.svelte
@@ -26,20 +26,20 @@
 
 	const db = useDatabase();
 
-	let localQuery = $state(data.query);
+	let localQuery = $state('');
 	let editorOpen = $state(false);
+
+	// Sync from external changes (runs before render)
+	$effect.pre(() => {
+		if (data.query !== localQuery) {
+			localQuery = data.query;
+		}
+	});
 
 	// Sync local query back to node data when it changes
 	$effect(() => {
 		if (localQuery !== data.query) {
 			db.canvas.updateNodeData(id, { query: localQuery });
-		}
-	});
-
-	// Update local when data changes externally
-	$effect(() => {
-		if (data.query !== localQuery) {
-			localQuery = data.query;
 		}
 	});
 

--- a/src/lib/components/erd-viewer.svelte
+++ b/src/lib/components/erd-viewer.svelte
@@ -117,7 +117,7 @@ import { errorToast } from "$lib/utils/toast";
   };
 
   // Export functionality
-  let flowContainer: HTMLElement;
+  let flowContainer = $state<HTMLElement>();
 
   const getFlowElement = () => flowContainer?.querySelector('.svelte-flow') as HTMLElement | null;
 

--- a/src/lib/components/onboarding/migration-track-selector.svelte
+++ b/src/lib/components/onboarding/migration-track-selector.svelte
@@ -17,8 +17,14 @@
 
 	const db = useDatabase();
 
-	let selectedBackground = $state<UserBackground>(onboardingStore.userBackground);
-	let showConfirmation = $state(selectedBackground !== "none");
+	let selectedBackground = $state<UserBackground>("none");
+	let showConfirmation = $state(false);
+
+	// Sync from store on mount
+	$effect.pre(() => {
+		selectedBackground = onboardingStore.userBackground;
+		showConfirmation = onboardingStore.userBackground !== "none";
+	});
 
 	const handleSelect = async (background: UserBackground) => {
 		selectedBackground = background;

--- a/src/lib/components/query-visual-viewer.svelte
+++ b/src/lib/components/query-visual-viewer.svelte
@@ -74,7 +74,7 @@ import { errorToast } from "$lib/utils/toast";
 	let edges = $derived(flowData.edges);
 
 	// Export functionality
-	let flowContainer: HTMLElement;
+	let flowContainer = $state<HTMLElement>();
 
 	const getFlowElement = () => flowContainer?.querySelector('.svelte-flow') as HTMLElement | null;
 

--- a/src/lib/components/shared-queries/repo-card.svelte
+++ b/src/lib/components/shared-queries/repo-card.svelte
@@ -28,18 +28,16 @@
 	const db = useDatabase();
 
 	let isExpanded = $state(false);
-	let editName = $state(repo.name);
-	let editRemoteUrl = $state(repo.remoteUrl);
-	let editBranch = $state(repo.branch);
+	let editName = $state('');
+	let editRemoteUrl = $state('');
+	let editBranch = $state('');
 	let isSaving = $state(false);
 
-	// Reset edit fields when expanded
-	$effect(() => {
-		if (isExpanded) {
-			editName = repo.name;
-			editRemoteUrl = repo.remoteUrl;
-			editBranch = repo.branch;
-		}
+	// Sync edit fields from repo (on mount and when expanded or repo changes)
+	$effect.pre(() => {
+		editName = repo.name;
+		editRemoteUrl = repo.remoteUrl;
+		editBranch = repo.branch;
 	});
 
 	const hasChanges = $derived(

--- a/src/lib/components/virtual-results-table.svelte
+++ b/src/lib/components/virtual-results-table.svelte
@@ -35,10 +35,10 @@
 	}: Props = $props();
 
 	// Virtual scrolling state
-	const ROW_HEIGHT = compact ? 28 : 37;
-	const HEADER_HEIGHT = compact ? 28 : 37;
+	const ROW_HEIGHT = $derived(compact ? 28 : 37);
+	const HEADER_HEIGHT = $derived(compact ? 28 : 37);
 	const OVERSCAN = 10;
-	const DEFAULT_COLUMN_WIDTH = compact ? 100 : 150;
+	const DEFAULT_COLUMN_WIDTH = $derived(compact ? 100 : 150);
 	const MIN_COLUMN_WIDTH = 50;
 
 	let scrollTop = $state(0);
@@ -146,6 +146,7 @@
 					<div class="relative flex items-center group">
 						<div class={["font-medium flex-1 truncate", compact ? "px-2 py-1" : "px-4 py-2"]}>{column}</div>
 						<!-- Resize handle -->
+						<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 						<div
 							class="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 group-hover:bg-border transition-colors"
 							onmousedown={(e) => startResize(i, e)}
@@ -172,6 +173,7 @@
 							</div>
 						{/if}
 						{#each columns as column}
+							<!-- svelte-ignore a11y_no_static_element_interactions -->
 							<div
 								class={["flex items-center overflow-hidden", compact ? "px-2 py-1" : "px-4 py-2"]}
 								oncontextmenu={() => onCellRightClick(row[column], column, row)}


### PR DESCRIPTION
## Summary
- Fixed 12 svelte-check warnings across 6 files
- Used `$effect.pre` for syncing props to local state instead of capturing initial values directly in `$state()` initializers  
- Changed `const` to `$derived` for values computed from reactive props
- Added `$state()` to `bind:this` element references
- Added `svelte-ignore` comments for intentional a11y patterns (resize handle, context menu)

## Test plan
- [x] `npm run check` passes with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)