### PR TITLE
Transform version for Windows alpha/beta releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,17 @@ jobs:
           echo "CERT_ID=$CERT_ID" >> $GITHUB_ENV
           echo "Certificate imported."
 
+      - name: Transform version for Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $configPath = "src-tauri/tauri.conf.json"
+          $config = Get-Content $configPath -Raw
+          # Transform 2026.4.0-beta.1 → 2026.4.0-1 or 2026.4.0-alpha.2 → 2026.4.0-2
+          $config = $config -replace '"version":\s*"([0-9.]+)-(alpha|beta)\.(\d+)"', '"version": "$1-$3"'
+          Set-Content $configPath $config
+          Write-Host "Transformed version for Windows build"
+
       - name: build and publish
         uses: tauri-apps/tauri-action@v0
         env:


### PR DESCRIPTION
## Summary
- Adds a conditional step in the release workflow that runs only on Windows
- Transforms versions like `2026.4.0-beta.1` → `2026.4.0-1` for Windows builds
- macOS and Linux builds retain the original version format

## Why
Windows installers have restrictions on version formats and don't support the "alpha" or "beta" text in version strings.

## Test plan
- [ ] Create a test tag with a beta version (e.g., `v2026.4.0-beta.2`)
- [ ] Verify the Windows build jobs transform the version correctly
- [ ] Confirm macOS and Linux builds retain the original version format

🤖 Generated with [Claude Code](https://claude.ai/claude-code)