### PR TITLE
Fix Query Table button SQL syntax for MS SQL Server

### DIFF
--- a/src/lib/components/canvas/nodes/table-node.svelte
+++ b/src/lib/components/canvas/nodes/table-node.svelte
@@ -33,7 +33,17 @@
 	}
 
 	function handleQueryTable() {
-		const query = `SELECT * FROM "${data.schemaName}"."${data.tableName}" LIMIT 100`;
+		const type = db.state.activeConnection?.type;
+		let query: string;
+
+		if (type === 'mssql') {
+			// MS SQL Server uses TOP and bracket identifiers
+			query = `SELECT TOP 100 * FROM [${data.schemaName}].[${data.tableName}]`;
+		} else {
+			// PostgreSQL, MySQL, MariaDB, SQLite, DuckDB use LIMIT
+			query = `SELECT * FROM "${data.schemaName}"."${data.tableName}" LIMIT 100`;
+		}
+
 		const queryNodeId = db.canvas.addQueryNode(query);
 		// Connect table node to query node
 		db.canvas.connect(id, queryNodeId, "output", "input");


### PR DESCRIPTION
## Summary
- Generate correct SQL syntax for the "Query Table" button based on database engine type
- MS SQL Server: `SELECT TOP 100 * FROM [schema].[table]`
- Other engines (PostgreSQL, MySQL, MariaDB, SQLite, DuckDB): `SELECT * FROM "schema"."table" LIMIT 100`

## Test plan
- [ ] Connect to PostgreSQL → Click "Query Table" → Verify query uses `LIMIT 100`
- [ ] Connect to MS SQL Server → Click "Query Table" → Verify query uses `TOP 100` with bracket identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)