### PR TITLE
Fix prerendering for learn lesson routes

### DIFF
--- a/src/routes/learn/[lessonId]/+page.ts
+++ b/src/routes/learn/[lessonId]/+page.ts
@@ -1,0 +1,5 @@
+import { LESSONS } from '$lib/tutorial/lessons';
+
+export function entries() {
+	return Object.keys(LESSONS).map((lessonId) => ({ lessonId }));
+}


### PR DESCRIPTION
## Summary
- Add `entries` export to `/learn/[lessonId]` route to fix prerendering

With `ssr=false`, the crawler renders pages client-side and can't discover dynamic routes from links. The `entries` function explicitly declares which lesson pages to prerender.

## Test plan
- [x] `npm run build` completes without prerender errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)