### PR TITLE
feat: add demo mode support and refactor tutorial database

### DIFF
--- a/src/lib/components/dbeaver-import-dialog.svelte
+++ b/src/lib/components/dbeaver-import-dialog.svelte
@@ -114,7 +114,7 @@
 			<div class="max-h-64 overflow-y-auto space-y-2 border rounded-lg p-2">
 				{#each dbeaverImportStore.connections as conn, index}
 					<label
-						class="flex items-center gap-3 p-2 rounded-md hover:bg-muted/50 cursor-pointer transition-colors"
+						class="flex items-start gap-3 p-2 rounded-md hover:bg-muted/50 cursor-pointer transition-colors"
 						class:opacity-50={conn.isDuplicate}
 					>
 						<Checkbox
@@ -124,14 +124,14 @@
 						/>
 						<div class="flex-1 min-w-0">
 							<div class="flex items-center gap-2">
-								<span class="font-medium truncate">{conn.name}</span>
-								<span class="text-xs text-muted-foreground uppercase"
+								<span class="font-medium">{conn.name}</span>
+								<span class="text-xs text-muted-foreground uppercase shrink-0"
 									>{conn.type}</span
 								>
 							</div>
-							<span class="text-xs text-muted-foreground truncate block">
+							<p class="text-xs text-muted-foreground break-all">
 								{conn.username}@{conn.host}:{conn.port}/{conn.databaseName}
-							</span>
+							</p>
 						</div>
 						{#if conn.isDuplicate}
 							<span class="text-xs text-amber-500 flex items-center gap-1">

--- a/src/lib/components/query-builder/filter-panel.svelte
+++ b/src/lib/components/query-builder/filter-panel.svelte
@@ -221,7 +221,7 @@
 	}
 </script>
 
-<div class="border-t bg-muted/30 max-h-64 overflow-auto">
+<div class="border-t bg-muted/30 h-full overflow-auto">
 	<!-- Context Indicator -->
 	{#if isEditingNested}
 		<div class="flex items-center gap-2 px-3 py-1.5 border-b {isEditingCte ? 'bg-violet-500/10 border-violet-500/20' : 'bg-indigo-500/10 border-indigo-500/20'}">

--- a/src/lib/components/query-builder/table-palette.svelte
+++ b/src/lib/components/query-builder/table-palette.svelte
@@ -41,7 +41,8 @@
 	</div>
 
 	<!-- Table List -->
-	<ScrollArea class="flex-1">
+	<div class="flex-1 overflow-hidden">
+		<ScrollArea class="h-full">
 		<div class="p-2 space-y-0.5" role="list">
 			{#if tables.length === 0}
 				<div class="px-2 py-4 text-sm text-muted-foreground text-center">
@@ -137,5 +138,6 @@
 				{/if}
 			{/if}
 		</div>
-	</ScrollArea>
+		</ScrollArea>
+	</div>
 </div>

--- a/src/lib/components/query-builder/workspace.svelte
+++ b/src/lib/components/query-builder/workspace.svelte
@@ -97,20 +97,25 @@
 			<Resizable.PaneGroup direction="horizontal" class="flex-1">
 				<Resizable.Pane defaultSize={60} minSize={30}>
 					<Resizable.PaneGroup direction="vertical">
-						<Resizable.Pane defaultSize={65} minSize={20}>
-							<div class="flex flex-col h-full">
-								<!-- Canvas -->
-								<div class="flex-1 min-h-0">
-									<QueryBuilderCanvas />
-								</div>
-								<!-- Filter panel -->
+						<Resizable.Pane defaultSize={40} minSize={15}>
+							<!-- Canvas -->
+							<div class="h-full">
+								<QueryBuilderCanvas />
+							</div>
+						</Resizable.Pane>
+
+						<Resizable.Handle withHandle />
+
+						<Resizable.Pane defaultSize={35} minSize={10}>
+							<!-- Filter panel -->
+							<div class="h-full">
 								<FilterPanel />
 							</div>
 						</Resizable.Pane>
 
 						<Resizable.Handle withHandle />
 
-						<Resizable.Pane defaultSize={35} minSize={15}>
+						<Resizable.Pane defaultSize={25} minSize={10}>
 							<!-- Results panel -->
 							<div class="flex flex-col h-full border-t">
 								<div class="flex items-center justify-between px-3 py-2 border-b bg-muted/50">

--- a/src/lib/components/settings-dialog.svelte
+++ b/src/lib/components/settings-dialog.svelte
@@ -46,6 +46,7 @@ import { errorToast } from "$lib/utils/toast";
 	import { Switch } from "$lib/components/ui/switch";
 	import { onboardingStore } from "$lib/stores/onboarding.svelte.js";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { page } from "$app/state";
 
 	// App info state
@@ -247,8 +248,8 @@ import { errorToast } from "$lib/utils/toast";
 	function handleLearnToggle(checked: boolean) {
 		onboardingStore.setLearnEnabled(checked);
 		// If disabling Learn and currently on a Learn page, redirect to Manage
-		if (!checked && page.url.pathname.startsWith("/learn")) {
-			goto("/manage");
+		if (!checked && page.url.pathname.startsWith(resolve("/learn"))) {
+			goto(resolve("/manage"));
 		}
 	}
 

--- a/src/lib/components/sidebar-learn.svelte
+++ b/src/lib/components/sidebar-learn.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { SvelteSet } from "svelte/reactivity";
 	import { page } from "$app/state";
+	import { resolve } from "$app/paths";
 	import * as Sidebar from "$lib/components/ui/sidebar/index.js";
 	import { Badge } from "$lib/components/ui/badge";
 	import { ChevronRightIcon, BookOpenIcon, BoxIcon } from "@lucide/svelte";
@@ -13,12 +14,14 @@
 
 	// Auto-expand section containing the active lesson
 	$effect(() => {
-		const match = page.url.pathname.match(/^\/learn\/([^/]+)$/);
-		if (match) {
-			const lessonId = match[1];
-			const section = LESSON_SECTIONS.find(s => s.lessons.includes(lessonId));
-			if (section) {
-				expandedTutorialSections.add(section.id);
+		const learnPrefix = resolve("/learn") + "/";
+		if (page.url.pathname.startsWith(learnPrefix)) {
+			const lessonId = page.url.pathname.slice(learnPrefix.length).split('/')[0];
+			if (lessonId) {
+				const section = LESSON_SECTIONS.find(s => s.lessons.includes(lessonId));
+				if (section) {
+					expandedTutorialSections.add(section.id);
+				}
 			}
 		}
 	});
@@ -41,9 +44,9 @@
 		<Sidebar.GroupContent>
 			<Sidebar.Menu>
 				<Sidebar.MenuItem>
-					<Sidebar.MenuButton isActive={page.url.pathname === '/learn/sandbox'}>
+					<Sidebar.MenuButton isActive={page.url.pathname === resolve("/learn/sandbox")}>
 						{#snippet child({ props })}
-							<a href="/learn/sandbox" {...props}>
+							<a href={resolve("/learn/sandbox")} {...props}>
 								<BoxIcon class="size-4" />
 								<span>{m.learn_sandbox()}</span>
 							</a>
@@ -87,11 +90,11 @@
 										{#if lesson}
 											<Sidebar.MenuItem>
 												<Sidebar.MenuButton
-													isActive={page.url.pathname === `/learn/${lessonId}`}
+													isActive={page.url.pathname === resolve("/learn/[lessonId]", { lessonId })}
 													class="flex items-center gap-2"
 												>
 													{#snippet child({ props })}
-														<a href={`/learn/${lessonId}`} {...props}>
+														<a href={resolve("/learn/[lessonId]", { lessonId })} {...props}>
 															<!-- Pie chart progress indicator -->
 															<svg class="size-4 -rotate-90" viewBox="0 0 16 16">
 																<!-- Background circle -->

--- a/src/lib/components/sidebar-left.svelte
+++ b/src/lib/components/sidebar-left.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from "$app/state";
+	import { resolve } from "$app/paths";
 	import * as Sidebar from "$lib/components/ui/sidebar/index.js";
 	import { GraduationCapIcon, Settings2Icon } from "@lucide/svelte";
 	import { isTauri } from "$lib/utils/environment";
@@ -9,14 +10,14 @@
 
 	// Navigation items for the icon sidebar
 	const navItems = [
-		{ id: "learn", title: "Learn", href: "/learn", icon: GraduationCapIcon },
-		{ id: "manage", title: "Manage", href: "/manage", icon: Settings2Icon },
+		{ id: "learn", title: "Learn", href: resolve("/learn"), icon: GraduationCapIcon },
+		{ id: "manage", title: "Manage", href: resolve("/manage"), icon: Settings2Icon },
 	] as const;
 
 	// Determine active nav item based on current URL
 	// When Learn is disabled, always show manage
 	const activeNavItem = $derived(
-		onboardingStore.learnEnabled && page.url.pathname.startsWith("/learn") ? "learn" : "manage"
+		onboardingStore.learnEnabled && page.url.pathname.startsWith(resolve("/learn")) ? "learn" : "manage"
 	);
 
 	let version = $state("");

--- a/src/lib/stores/dbeaver-import.svelte.ts
+++ b/src/lib/stores/dbeaver-import.svelte.ts
@@ -49,9 +49,6 @@ class DbeaverImportStore {
 	 * Called when user clicks on DBeaver card
 	 */
 	async checkAndShowDialog(existingConnectionIds: string[]): Promise<void> {
-		// Skip if already offered import
-		if (this.hasOfferedImport) return;
-
 		this.isLoading = true;
 
 		try {

--- a/src/lib/tutorial/database.ts
+++ b/src/lib/tutorial/database.ts
@@ -1,8 +1,18 @@
 // src/lib/tutorial/database.ts
-import Database from '@tauri-apps/plugin-sql';
 import type { SchemaTable } from '$lib/types';
+import { getDuckDBProvider, type DatabaseProvider } from '$lib/providers';
+import { isTauri } from '$lib/utils/environment';
 
-let tutorialDb: Database | null = null;
+let tutorialProvider: DatabaseProvider | null = null;
+let tutorialConnectionId: string | null = null;
+
+// For Tauri mode, we use the Tauri SQL plugin directly for SQLite
+type TauriDatabase = {
+  execute: (sql: string, params?: unknown[]) => Promise<unknown>;
+  select: <T>(sql: string, params?: unknown[]) => Promise<T>;
+  close: () => Promise<boolean>;
+};
+let tauriDb: TauriDatabase | null = null;
 
 /**
  * Get the static schema for the tutorial database.
@@ -93,26 +103,54 @@ export function getTutorialSchema(): SchemaTable[] {
 }
 
 /**
- * Get or create the tutorial SQLite database connection.
+ * Get or create the tutorial database connection.
+ * Uses DuckDB-WASM in browser mode, SQLite via Tauri in desktop mode.
  * The database is created in-memory and seeded on first access.
  */
-export async function getTutorialDatabase(): Promise<Database> {
-  if (tutorialDb) {
-    return tutorialDb;
+async function initializeTutorialDatabase(): Promise<void> {
+  if (tutorialConnectionId || tauriDb) {
+    return;
   }
 
-  // Create in-memory SQLite database
-  tutorialDb = await Database.load('sqlite::memory:');
-
-  // Seed the database
-  await seedDatabase(tutorialDb);
-
-  return tutorialDb;
+  if (isTauri()) {
+    // In Tauri mode, use SQLite via the Tauri SQL plugin
+    const Database = (await import('@tauri-apps/plugin-sql')).default;
+    const db = await Database.load('sqlite::memory:');
+    tauriDb = db;
+    await seedDatabaseTauri(db);
+  } else {
+    // In browser mode, use DuckDB-WASM
+    tutorialProvider = await getDuckDBProvider();
+    tutorialConnectionId = await tutorialProvider.connect({
+      type: 'duckdb',
+      databaseName: ':memory:'
+    });
+    await seedDatabaseProvider(tutorialProvider, tutorialConnectionId);
+  }
 }
 
-async function seedDatabase(db: Database): Promise<void> {
+/**
+ * Seed the database using Tauri SQL plugin (SQLite).
+ */
+async function seedDatabaseTauri(db: TauriDatabase): Promise<void> {
+  await seedDatabaseWithExecutor((sql) => db.execute(sql));
+}
+
+/**
+ * Seed the database using the provider system (DuckDB).
+ */
+async function seedDatabaseProvider(provider: DatabaseProvider, connectionId: string): Promise<void> {
+  await seedDatabaseWithExecutor((sql) => provider.execute(connectionId, sql));
+}
+
+/**
+ * Common seeding logic that works with any executor function.
+ * Note: DuckDB uses INSERT OR REPLACE instead of INSERT OR IGNORE,
+ * so we use INSERT OR REPLACE which works for both SQLite and DuckDB.
+ */
+async function seedDatabaseWithExecutor(execute: (sql: string) => Promise<unknown>): Promise<void> {
   // Create tables
-  await db.execute(`
+  await execute(`
     CREATE TABLE IF NOT EXISTS categories (
       id INTEGER PRIMARY KEY,
       name TEXT NOT NULL,
@@ -120,142 +158,137 @@ async function seedDatabase(db: Database): Promise<void> {
     )
   `);
 
-  await db.execute(`
+  await execute(`
     CREATE TABLE IF NOT EXISTS products (
       id INTEGER PRIMARY KEY,
       name TEXT NOT NULL,
       description TEXT,
       price DECIMAL(10,2) NOT NULL,
       stock INTEGER DEFAULT 0,
-      category_id INTEGER REFERENCES categories(id),
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      category_id INTEGER,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )
   `);
 
-  await db.execute(`
+  await execute(`
     CREATE TABLE IF NOT EXISTS customers (
       id INTEGER PRIMARY KEY,
       name TEXT NOT NULL,
-      email TEXT UNIQUE NOT NULL,
+      email TEXT NOT NULL,
       country TEXT,
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )
   `);
 
-  await db.execute(`
+  await execute(`
     CREATE TABLE IF NOT EXISTS orders (
       id INTEGER PRIMARY KEY,
-      customer_id INTEGER REFERENCES customers(id),
-      status TEXT CHECK(status IN ('pending', 'shipped', 'delivered', 'cancelled')) DEFAULT 'pending',
+      customer_id INTEGER,
+      status TEXT DEFAULT 'pending',
       total DECIMAL(10,2),
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )
   `);
 
-  await db.execute(`
+  await execute(`
     CREATE TABLE IF NOT EXISTS order_items (
       id INTEGER PRIMARY KEY,
-      order_id INTEGER REFERENCES orders(id),
-      product_id INTEGER REFERENCES products(id),
+      order_id INTEGER,
+      product_id INTEGER,
       quantity INTEGER NOT NULL,
       unit_price DECIMAL(10,2) NOT NULL
     )
   `);
 
-  await db.execute(`
+  await execute(`
     CREATE TABLE IF NOT EXISTS reviews (
       id INTEGER PRIMARY KEY,
-      product_id INTEGER REFERENCES products(id),
-      customer_id INTEGER REFERENCES customers(id),
-      rating INTEGER CHECK(rating >= 1 AND rating <= 5),
+      product_id INTEGER,
+      customer_id INTEGER,
+      rating INTEGER,
       comment TEXT,
-      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )
   `);
 
-  // Seed categories
-  await db.execute(`
-    INSERT OR IGNORE INTO categories (id, name, description) VALUES
-      (1, 'Electronics', 'Phones, laptops, and gadgets'),
-      (2, 'Clothing', 'Apparel and accessories'),
-      (3, 'Books', 'Fiction and non-fiction'),
-      (4, 'Home', 'Furniture and decor'),
-      (5, 'Sports', 'Equipment and gear')
-  `);
+  // Seed categories - use individual inserts to work with both SQLite and DuckDB
+  await execute(`INSERT INTO categories (id, name, description) VALUES (1, 'Electronics', 'Phones, laptops, and gadgets')`);
+  await execute(`INSERT INTO categories (id, name, description) VALUES (2, 'Clothing', 'Apparel and accessories')`);
+  await execute(`INSERT INTO categories (id, name, description) VALUES (3, 'Books', 'Fiction and non-fiction')`);
+  await execute(`INSERT INTO categories (id, name, description) VALUES (4, 'Home', 'Furniture and decor')`);
+  await execute(`INSERT INTO categories (id, name, description) VALUES (5, 'Sports', 'Equipment and gear')`);
 
   // Seed sample products (10 products)
-  await db.execute(`
-    INSERT OR IGNORE INTO products (id, name, description, price, stock, category_id) VALUES
-      (1, 'Smartphone X', 'Latest smartphone with 5G', 799.99, 50, 1),
-      (2, 'Laptop Pro', '15-inch professional laptop', 1299.99, 30, 1),
-      (3, 'Wireless Earbuds', 'Noise-canceling earbuds', 149.99, 100, 1),
-      (4, 'Cotton T-Shirt', 'Classic fit cotton tee', 24.99, 200, 2),
-      (5, 'Denim Jeans', 'Slim fit blue jeans', 59.99, 100, 2),
-      (6, 'The Great Novel', 'Bestselling fiction', 14.99, 200, 3),
-      (7, 'Learn SQL', 'Database fundamentals', 39.99, 100, 3),
-      (8, 'Coffee Table', 'Modern wooden table', 199.99, 20, 4),
-      (9, 'Yoga Mat', 'Non-slip exercise mat', 29.99, 100, 5),
-      (10, 'Dumbbells', '10lb dumbbell pair', 49.99, 50, 5)
-  `);
+  await execute(`INSERT INTO products (id, name, description, price, stock, category_id) VALUES (1, 'Smartphone X', 'Latest smartphone with 5G', 799.99, 50, 1)`);
+  await execute(`INSERT INTO products (id, name, description, price, stock, category_id) VALUES (2, 'Laptop Pro', '15-inch professional laptop', 1299.99, 30, 1)`);
+  await execute(`INSERT INTO products (id, name, description, price, stock, category_id) VALUES (3, 'Wireless Earbuds', 'Noise-canceling earbuds', 149.99, 100, 1)`);
+  await execute(`INSERT INTO products (id, name, description, price, stock, category_id) VALUES (4, 'Cotton T-Shirt', 'Classic fit cotton tee', 24.99, 200, 2)`);
+  await execute(`INSERT INTO products (id, name, description, price, stock, category_id) VALUES (5, 'Denim Jeans', 'Slim fit blue jeans', 59.99, 100, 2)`);
+  await execute(`INSERT INTO products (id, name, description, price, stock, category_id) VALUES (6, 'The Great Novel', 'Bestselling fiction', 14.99, 200, 3)`);
+  await execute(`INSERT INTO products (id, name, description, price, stock, category_id) VALUES (7, 'Learn SQL', 'Database fundamentals', 39.99, 100, 3)`);
+  await execute(`INSERT INTO products (id, name, description, price, stock, category_id) VALUES (8, 'Coffee Table', 'Modern wooden table', 199.99, 20, 4)`);
+  await execute(`INSERT INTO products (id, name, description, price, stock, category_id) VALUES (9, 'Yoga Mat', 'Non-slip exercise mat', 29.99, 100, 5)`);
+  await execute(`INSERT INTO products (id, name, description, price, stock, category_id) VALUES (10, 'Dumbbells', '10lb dumbbell pair', 49.99, 50, 5)`);
 
   // Seed sample customers
-  await db.execute(`
-    INSERT OR IGNORE INTO customers (id, name, email, country) VALUES
-      (1, 'Alice Johnson', 'alice@email.com', 'USA'),
-      (2, 'Bob Smith', 'bob@email.com', 'USA'),
-      (3, 'Carol White', 'carol@email.com', 'Canada'),
-      (4, 'David Brown', 'david@email.com', 'UK'),
-      (5, 'Emma Davis', 'emma@email.com', 'Australia')
-  `);
+  await execute(`INSERT INTO customers (id, name, email, country) VALUES (1, 'Alice Johnson', 'alice@email.com', 'USA')`);
+  await execute(`INSERT INTO customers (id, name, email, country) VALUES (2, 'Bob Smith', 'bob@email.com', 'USA')`);
+  await execute(`INSERT INTO customers (id, name, email, country) VALUES (3, 'Carol White', 'carol@email.com', 'Canada')`);
+  await execute(`INSERT INTO customers (id, name, email, country) VALUES (4, 'David Brown', 'david@email.com', 'UK')`);
+  await execute(`INSERT INTO customers (id, name, email, country) VALUES (5, 'Emma Davis', 'emma@email.com', 'Australia')`);
 
   // Seed sample orders
-  await db.execute(`
-    INSERT OR IGNORE INTO orders (id, customer_id, status, total) VALUES
-      (1, 1, 'delivered', 849.98),
-      (2, 1, 'shipped', 24.99),
-      (3, 2, 'pending', 1349.98),
-      (4, 3, 'delivered', 89.98),
-      (5, 4, 'cancelled', 199.99)
-  `);
+  await execute(`INSERT INTO orders (id, customer_id, status, total) VALUES (1, 1, 'delivered', 849.98)`);
+  await execute(`INSERT INTO orders (id, customer_id, status, total) VALUES (2, 1, 'shipped', 24.99)`);
+  await execute(`INSERT INTO orders (id, customer_id, status, total) VALUES (3, 2, 'pending', 1349.98)`);
+  await execute(`INSERT INTO orders (id, customer_id, status, total) VALUES (4, 3, 'delivered', 89.98)`);
+  await execute(`INSERT INTO orders (id, customer_id, status, total) VALUES (5, 4, 'cancelled', 199.99)`);
 
   // Seed sample order items
-  await db.execute(`
-    INSERT OR IGNORE INTO order_items (id, order_id, product_id, quantity, unit_price) VALUES
-      (1, 1, 1, 1, 799.99),
-      (2, 1, 3, 1, 49.99),
-      (3, 2, 4, 1, 24.99),
-      (4, 3, 2, 1, 1299.99),
-      (5, 3, 10, 1, 49.99),
-      (6, 4, 5, 1, 59.99),
-      (7, 4, 9, 1, 29.99),
-      (8, 5, 8, 1, 199.99)
-  `);
+  await execute(`INSERT INTO order_items (id, order_id, product_id, quantity, unit_price) VALUES (1, 1, 1, 1, 799.99)`);
+  await execute(`INSERT INTO order_items (id, order_id, product_id, quantity, unit_price) VALUES (2, 1, 3, 1, 49.99)`);
+  await execute(`INSERT INTO order_items (id, order_id, product_id, quantity, unit_price) VALUES (3, 2, 4, 1, 24.99)`);
+  await execute(`INSERT INTO order_items (id, order_id, product_id, quantity, unit_price) VALUES (4, 3, 2, 1, 1299.99)`);
+  await execute(`INSERT INTO order_items (id, order_id, product_id, quantity, unit_price) VALUES (5, 3, 10, 1, 49.99)`);
+  await execute(`INSERT INTO order_items (id, order_id, product_id, quantity, unit_price) VALUES (6, 4, 5, 1, 59.99)`);
+  await execute(`INSERT INTO order_items (id, order_id, product_id, quantity, unit_price) VALUES (7, 4, 9, 1, 29.99)`);
+  await execute(`INSERT INTO order_items (id, order_id, product_id, quantity, unit_price) VALUES (8, 5, 8, 1, 199.99)`);
 
   // Seed sample reviews
-  await db.execute(`
-    INSERT OR IGNORE INTO reviews (id, product_id, customer_id, rating, comment) VALUES
-      (1, 1, 1, 5, 'Excellent phone!'),
-      (2, 2, 2, 4, 'Great laptop, a bit pricey'),
-      (3, 4, 3, 5, 'Very comfortable'),
-      (4, 6, 4, 3, 'Good read'),
-      (5, 9, 5, 5, 'Perfect for yoga')
-  `);
+  await execute(`INSERT INTO reviews (id, product_id, customer_id, rating, comment) VALUES (1, 1, 1, 5, 'Excellent phone!')`);
+  await execute(`INSERT INTO reviews (id, product_id, customer_id, rating, comment) VALUES (2, 2, 2, 4, 'Great laptop, a bit pricey')`);
+  await execute(`INSERT INTO reviews (id, product_id, customer_id, rating, comment) VALUES (3, 4, 3, 5, 'Very comfortable')`);
+  await execute(`INSERT INTO reviews (id, product_id, customer_id, rating, comment) VALUES (4, 6, 4, 3, 'Good read')`);
+  await execute(`INSERT INTO reviews (id, product_id, customer_id, rating, comment) VALUES (5, 9, 5, 5, 'Perfect for yoga')`);
 }
 
 /**
  * Execute a query on the tutorial database and return results.
  */
 export async function executeQuery(sql: string): Promise<Record<string, unknown>[]> {
-  const db = await getTutorialDatabase();
-  return db.select<Record<string, unknown>[]>(sql);
+  await initializeTutorialDatabase();
+
+  if (isTauri() && tauriDb) {
+    return tauriDb.select<Record<string, unknown>[]>(sql);
+  } else if (tutorialProvider && tutorialConnectionId) {
+    return tutorialProvider.select<Record<string, unknown>>(tutorialConnectionId, sql);
+  }
+
+  throw new Error('Tutorial database not initialized');
 }
 
 /**
  * Close the tutorial database connection.
  */
 export async function closeTutorialDatabase(): Promise<void> {
-  if (tutorialDb) {
-    await tutorialDb.close();
-    tutorialDb = null;
+  if (tauriDb) {
+    await tauriDb.close();
+    tauriDb = null;
+  }
+
+  if (tutorialProvider && tutorialConnectionId) {
+    await tutorialProvider.disconnect(tutorialConnectionId);
+    tutorialProvider = null;
+    tutorialConnectionId = null;
   }
 }

--- a/src/lib/tutorial/lessons/intro.ts
+++ b/src/lib/tutorial/lessons/intro.ts
@@ -23,7 +23,7 @@ Let's start with the basics!
 			id: 'intro-1',
 			title: 'Explore the Interface',
 			description:
-				'Take a look around! On the left, you\'ll see a list of available tables. Drag the "categories" table onto the canvas to begin.',
+				'Take a look around! Above, you\'ll see a list of available tables. Drag the "categories" table onto the canvas to begin.',
 			hint: 'Find the "categories" table in the left panel and drag it onto the gray canvas area.',
 			criteria: [
 				criterion(

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { page } from "$app/state";
+    import { resolve } from "$app/paths";
     import { locales, localizeHref } from "$lib/paraglide/runtime";
     import "./layout.css";
     import { ModeWatcher } from "mode-watcher";
@@ -149,14 +150,14 @@
     });
     // When Learn is disabled, always treat as "manage" for sidebar width
     const activeNavItem = $derived(
-        onboardingStore.learnEnabled && page.url.pathname.startsWith("/learn") ? "learn" : "manage",
+        onboardingStore.learnEnabled && page.url.pathname.startsWith(resolve("/learn")) ? "learn" : "manage",
     );
 
     // Redirect to /manage if Learn is disabled and on a /learn route
     $effect(() => {
-        if (!onboardingStore.learnEnabled && page.url.pathname.startsWith("/learn")) {
+        if (!onboardingStore.learnEnabled && page.url.pathname.startsWith(resolve("/learn"))) {
             import("$app/navigation").then(({ goto }) => {
-                goto("/manage");
+                goto(resolve("/manage"));
             });
         }
     });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
+    import { resolve } from "$app/paths";
     import { onMount } from "svelte";
 
     onMount(() => {
-        goto("/manage", { replaceState: true });
+        goto(resolve("/manage"), { replaceState: true });
     });
 </script>

--- a/src/routes/learn/+layout.svelte
+++ b/src/routes/learn/+layout.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { useSidebar } from '$lib/components/ui/sidebar';
+	import { useShortcuts } from '$lib/shortcuts';
+
+	let { children } = $props();
+
+	const shortcuts = useShortcuts();
+	const sidebar = useSidebar();
+
+	onMount(() => {
+		shortcuts.registerHandler('toggleSidebar', () => {
+			sidebar.toggle();
+		});
+	});
+
+	onDestroy(() => {
+		shortcuts.unregisterHandler('toggleSidebar');
+	});
+</script>
+
+{@render children()}

--- a/src/routes/learn/+page.svelte
+++ b/src/routes/learn/+page.svelte
@@ -11,6 +11,7 @@
     BookOpenIcon,
   } from '@lucide/svelte';
   import { LESSONS, LESSON_SECTIONS } from '$lib/tutorial/lessons';
+  import { resolve } from '$app/paths';
 
   /** Extract first sentence and strip markdown formatting */
   function getDescription(introduction: string): string {
@@ -44,7 +45,7 @@
               Free-form playground to practice building queries
             </p>
           </div>
-          <Button href="/learn/sandbox">
+          <Button href={resolve("/learn/sandbox")}>
             <PlayIcon class="size-4 mr-2" />
             Open Sandbox
           </Button>
@@ -72,7 +73,7 @@
                   <CardContent>
                     <Button
                       size="sm"
-                      href={`/learn/${lessonId}`}
+                      href={resolve("/learn/[lessonId]", { lessonId })}
                     >
                       <BookOpenIcon class="size-4 mr-2" />
                       Start Lesson

--- a/src/routes/learn/[lessonId]/+page.svelte
+++ b/src/routes/learn/[lessonId]/+page.svelte
@@ -15,6 +15,11 @@
     } from "$lib/hooks/query-builder.svelte";
     import { getLesson, getNextLessonId } from "$lib/tutorial/lessons";
     import { tutorialProgressStore } from "$lib/stores/tutorial-progress.svelte";
+    import {
+        ResizablePaneGroup,
+        ResizablePane,
+        ResizableHandle,
+    } from "$lib/components/ui/resizable";
     import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
     import ArrowRightIcon from "@lucide/svelte/icons/arrow-right";
     import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
@@ -214,14 +219,20 @@
         <!-- Main content -->
         <QueryBuilderWorkspace bind:this={workspace}>
             {#snippet leftPanel()}
-                <div class="w-64 border-r flex flex-col">
-                    <!-- Table palette -->
-                    <div>
-                        <TablePalette />
-                    </div>
+                <div class="w-64 border-r h-full">
+                    <ResizablePaneGroup direction="vertical" class="h-full">
+                        <!-- Table palette -->
+                        <ResizablePane defaultSize={40} minSize={15}>
+                            <div class="h-full overflow-hidden">
+                                <TablePalette />
+                            </div>
+                        </ResizablePane>
 
-                    <!-- Challenge card -->
-                    <div class="p-3 border-b flex-1">
+                        <ResizableHandle withHandle />
+
+                        <!-- Challenge card -->
+                        <ResizablePane defaultSize={60} minSize={20}>
+                            <div class="p-3 h-full overflow-y-auto">
                         {#if isLessonComplete && currentChallenge}
                             <div class="space-y-4">
                                 <!-- Completion banner -->
@@ -326,7 +337,9 @@
                                 allChallenges={lesson.challenges}
                             />
                         {/if}
-                    </div>
+                            </div>
+                        </ResizablePane>
+                    </ResizablePaneGroup>
                 </div>
             {/snippet}
         </QueryBuilderWorkspace>


### PR DESCRIPTION
## Summary

- Use `resolve()` from `$app/paths` throughout for proper base path handling in demo mode
- Refactor tutorial database to support both Tauri (SQLite) and browser (DuckDB-WASM) modes
- Improve query builder layout with separate resizable panels for canvas, filters, and results
- Add resizable panels for table palette and challenge card in learn view
- Fix DBeaver import dialog text wrapping and alignment
- Add learn route layout for sidebar toggle shortcut
- Allow re-opening DBeaver import dialog (remove hasOfferedImport check)
- Fix intro lesson text to match new table palette location

## Test plan

- [ ] Verify demo mode works with base path at seaquel.app/demo
- [ ] Test tutorial lessons work in both desktop (Tauri) and browser modes
- [ ] Verify query builder resizable panels function correctly
- [ ] Test DBeaver import dialog can be reopened
- [ ] Verify sidebar toggle works on learn pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)