### PR TITLE
feat: add "All (YOLO)" option to query result pagination

### DIFF
--- a/src/lib/components/query-editor.svelte
+++ b/src/lib/components/query-editor.svelte
@@ -998,7 +998,7 @@ import { errorToast } from "$lib/utils/toast";
 								/>
 							{/if}
 
-							{#if activeResult.totalPages > 1 && currentViewMode === 'table'}
+							{#if (activeResult.totalPages > 1 || activeResult.pageSize === 0) && currentViewMode === 'table'}
 								<QueryPagination
 									page={activeResult.page}
 									pageSize={activeResult.pageSize}

--- a/src/lib/components/query-editor/query-pagination.svelte
+++ b/src/lib/components/query-editor/query-pagination.svelte
@@ -23,8 +23,9 @@
 	let { page, pageSize, totalPages, totalRows, isExecuting, onGoToPage, onSetPageSize }: Props =
 		$props();
 
-	const start = $derived((page - 1) * pageSize + 1);
-	const end = $derived(Math.min(page * pageSize, totalRows));
+	const isAllRows = $derived(pageSize === 0);
+	const start = $derived(isAllRows ? 1 : (page - 1) * pageSize + 1);
+	const end = $derived(isAllRows ? totalRows : Math.min(page * pageSize, totalRows));
 </script>
 
 <div class="flex items-center justify-between p-2 border-t bg-muted/30 shrink-0 text-xs">
@@ -39,7 +40,7 @@
 					size: "sm"
 				}) + " h-7 gap-1 text-xs"}
 			>
-				{pageSize} rows
+				{isAllRows ? "All (YOLO)" : `${pageSize} rows`}
 				<ChevronDownIcon class="size-3" />
 			</DropdownMenu.Trigger>
 			<DropdownMenu.Content align="end">
@@ -51,6 +52,13 @@
 						{m.query_rows_count({ count: size })}
 					</DropdownMenu.Item>
 				{/each}
+				<DropdownMenu.Separator />
+				<DropdownMenu.Item
+					onclick={() => onSetPageSize(0)}
+					class={isAllRows ? "bg-accent" : ""}
+				>
+					All (YOLO)
+				</DropdownMenu.Item>
 			</DropdownMenu.Content>
 		</DropdownMenu.Root>
 

--- a/src/lib/hooks/database/query-execution.svelte.ts
+++ b/src/lib/hooks/database/query-execution.svelte.ts
@@ -184,7 +184,8 @@ export class QueryExecutionManager {
       }
 
       // Add pagination if we successfully got a count (it's a SELECT)
-      if (totalRows >= 0) {
+      // pageSize === 0 means "all rows" — skip LIMIT/OFFSET
+      if (totalRows >= 0 && pageSize > 0) {
         const offset = (page - 1) * pageSize;
         if (isMssql) {
           // SQL Server uses OFFSET FETCH syntax (requires ORDER BY)
@@ -224,7 +225,7 @@ export class QueryExecutionManager {
       totalRows = dbResult?.length ?? 0;
     }
 
-    const totalPages = hasPagination ? 1 : Math.max(1, Math.ceil(totalRows / pageSize));
+    const totalPages = hasPagination || pageSize === 0 ? 1 : Math.max(1, Math.ceil(totalRows / pageSize));
 
     // Try to extract source table info for CRUD operations
     const tableInfo = extractTableFromSelect(baseQuery);


### PR DESCRIPTION
## Summary
- Adds an "All (YOLO)" entry below the 1000 rows option in the query result pagination dropdown
- Loads all results without LIMIT/OFFSET when selected (uses `pageSize=0` as sentinel)
- Keeps the pagination bar visible in "all rows" mode so users can switch back to a paginated size

## Test plan
- [ ] Run a query returning >100 rows, open the pagination dropdown, verify "All (YOLO)" appears below 1000 with a separator
- [ ] Select "All (YOLO)" and confirm all rows load, the button reads "All (YOLO)", and the "Showing" text reflects all rows
- [ ] Switch back to a numbered page size (e.g. 100) and confirm pagination resumes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)