### PR TITLE
refactor: extract shared utilities and centralize error handling

### DIFF
--- a/src/lib/components/canvas/nodes/chart-node.svelte
+++ b/src/lib/components/canvas/nodes/chart-node.svelte
@@ -2,7 +2,7 @@
 	import { Handle, Position, NodeResizer } from "@xyflow/svelte";
 	import type { CanvasChartNodeData } from "$lib/types/canvas";
 	import type { ChartType } from "$lib/types";
-	import { useDatabase } from "$lib/hooks/database.svelte.js";
+	import { useCanvasNode } from "./use-canvas-node.svelte.js";
 	import { BarChart, LineChart, PieChart, ScatterChart } from "layerchart";
 	import ChartBarIcon from "@lucide/svelte/icons/chart-bar";
 	import ChartLineIcon from "@lucide/svelte/icons/chart-line";
@@ -22,20 +22,12 @@
 
 	let { id, data, isConnectable = true, selected = false }: Props = $props();
 
-	const db = useDatabase();
-
-	function handleRemove() {
-		db.canvas.removeNode(id);
-	}
+	const { db, handleRemove, handleResizeEnd } = useCanvasNode(() => id);
 
 	function handleChartTypeChange(newType: ChartType) {
 		db.canvas.updateNodeData(id, {
 			chartConfig: { ...data.chartConfig, type: newType },
 		});
-	}
-
-	function handleResizeEnd(_event: unknown, params: { width: number; height: number }) {
-		db.canvas.updateNodeDimensions(id, params.width, params.height);
 	}
 
 	// Transform data for the chart

--- a/src/lib/components/canvas/nodes/query-node.svelte
+++ b/src/lib/components/canvas/nodes/query-node.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Handle, Position, NodeResizer } from "@xyflow/svelte";
 	import type { CanvasQueryNodeData } from "$lib/types/canvas";
-	import { useDatabase } from "$lib/hooks/database.svelte.js";
+	import { useCanvasNode } from "./use-canvas-node.svelte.js";
 	import SuggestiveHandle from "../suggestive-handle.svelte";
 	import CodeIcon from "@lucide/svelte/icons/code";
 	import PlayIcon from "@lucide/svelte/icons/play";
@@ -24,7 +24,7 @@
 
 	let { id, data, isConnectable = true, selected = false }: Props = $props();
 
-	const db = useDatabase();
+	const { db, handleRemove, handleResizeEnd } = useCanvasNode(() => id);
 
 	let localQuery = $state('');
 	let editorOpen = $state(false);
@@ -50,14 +50,6 @@
 	async function handleExecuteAndClose() {
 		editorOpen = false;
 		await db.canvas.executeQueryNode(id);
-	}
-
-	function handleRemove() {
-		db.canvas.removeNode(id);
-	}
-
-	function handleResizeEnd(_event: unknown, params: { width: number; height: number }) {
-		db.canvas.updateNodeDimensions(id, params.width, params.height);
 	}
 
 	// Get preview lines for display

--- a/src/lib/components/canvas/nodes/table-node.svelte
+++ b/src/lib/components/canvas/nodes/table-node.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Position, NodeResizer } from "@xyflow/svelte";
 	import type { CanvasTableNodeData } from "$lib/types/canvas";
-	import { useDatabase } from "$lib/hooks/database.svelte.js";
+	import { useCanvasNode } from "./use-canvas-node.svelte.js";
 	import SuggestiveHandle from "../suggestive-handle.svelte";
 	import TableIcon from "@lucide/svelte/icons/table";
 	import Trash2Icon from "@lucide/svelte/icons/trash-2";
@@ -22,15 +22,11 @@
 
 	let { id, data, isConnectable = true, selected = false }: Props = $props();
 
-	const db = useDatabase();
+	const { db, handleRemove, handleResizeEnd } = useCanvasNode(() => id);
 
 	const maxVisibleColumns = 12;
 	const visibleColumns = $derived(data.columns.slice(0, maxVisibleColumns));
 	const hiddenColumnCount = $derived(data.columns.length - maxVisibleColumns);
-
-	function handleRemove() {
-		db.canvas.removeNode(id);
-	}
 
 	function handleQueryTable() {
 		const type = db.state.activeConnection?.type;
@@ -47,10 +43,6 @@
 		const queryNodeId = db.canvas.addQueryNode(query);
 		// Connect table node to query node
 		db.canvas.connect(id, queryNodeId, "output", "input");
-	}
-
-	function handleResizeEnd(_event: unknown, params: { width: number; height: number }) {
-		db.canvas.updateNodeDimensions(id, params.width, params.height);
 	}
 
 	// Suggestions for the output handle

--- a/src/lib/components/canvas/nodes/use-canvas-node.svelte.ts
+++ b/src/lib/components/canvas/nodes/use-canvas-node.svelte.ts
@@ -1,0 +1,26 @@
+import { useDatabase } from '$lib/hooks/database.svelte.js';
+
+/**
+ * Shared logic for all canvas node types.
+ * Provides common handlers for node removal and resizing.
+ *
+ * Accepts a getter to read `id` reactively and avoid the
+ * `state_referenced_locally` warning from Svelte 5.
+ */
+export function useCanvasNode(getId: () => string) {
+	const db = useDatabase();
+
+	function handleRemove() {
+		db.canvas.removeNode(getId());
+	}
+
+	function handleResizeEnd(_event: unknown, params: { width: number; height: number }) {
+		db.canvas.updateNodeDimensions(getId(), params.width, params.height);
+	}
+
+	return {
+		db,
+		handleRemove,
+		handleResizeEnd
+	};
+}

--- a/src/lib/components/query-editor.svelte
+++ b/src/lib/components/query-editor.svelte
@@ -19,12 +19,14 @@ import { errorToast } from "$lib/utils/toast";
 	import VirtualResultsTable from "$lib/components/virtual-results-table.svelte";
 	import { formatConfig, getExportContent, type ExportFormat } from "$lib/utils/export-formats.js";
 	import { m } from "$lib/paraglide/messages.js";
+	import { copyCell as clipboardCopyCell, copyRowAsJSON as clipboardCopyRowAsJSON, copyColumn as clipboardCopyColumn } from "$lib/utils/clipboard";
 	import { splitSqlStatements, getStatementAtOffset } from "$lib/db/sql-parser.js";
 	import { hasParameters, extractParameters, createDefaultParameters } from "$lib/db/query-params.js";
 	import type { QueryParameter, ParameterValue } from "$lib/types";
 	import QueryExampleCard from "$lib/components/empty-states/query-example-card.svelte";
 	import { sampleQueries } from "$lib/config/sample-queries.js";
 	import PlusIcon from "@lucide/svelte/icons/plus";
+	import { EmptyState } from "$lib/components/ui/empty-state";
 
 	// Import subcomponents
 	import {
@@ -516,26 +518,17 @@ import { errorToast } from "$lib/utils/toast";
 
 	const copyCell = async () => {
 		if (!contextCell) return;
-		const value = contextCell.value === null || contextCell.value === undefined ? "" : String(contextCell.value);
-		await navigator.clipboard.writeText(value);
-		toast.success(m.query_cell_copied());
+		await clipboardCopyCell(contextCell.value);
 	};
 
 	const copyRowAsJSON = async () => {
 		if (!contextCell) return;
-		await navigator.clipboard.writeText(JSON.stringify(contextCell.row, null, 2));
-		toast.success(m.query_row_copied());
+		await clipboardCopyRowAsJSON(contextCell.row);
 	};
 
 	const copyColumn = async () => {
 		if (!contextCell || !activeResult) return;
-		const col = contextCell.column;
-		const values = activeResult.rows
-			.map(row => row[col])
-			.map(v => v === null || v === undefined ? "" : String(v))
-			.join("\n");
-		await navigator.clipboard.writeText(values);
-		toast.success(m.query_column_copied());
+		await clipboardCopyColumn(contextCell.column, activeResult.rows);
 	};
 
 	// Register keyboard shortcuts
@@ -673,13 +666,12 @@ import { errorToast } from "$lib/utils/toast";
 						{#if currentViewMode === 'explain' && explainResult}
 							<ExplainResultPane {explainResult} />
 						{:else if currentViewMode === 'explain' && !explainResult}
-							<div class="flex-1 flex items-center justify-center p-6">
-								<div class="text-center max-w-xs">
-									<DatabaseIcon class="size-10 mx-auto mb-3 opacity-20" />
-									<p class="font-medium mb-2">No Explain Results</p>
-									<p class="text-xs text-muted-foreground mb-4">
-										Analyze your query's execution plan to understand how the database processes it.
-									</p>
+							<EmptyState
+								icon={DatabaseIcon}
+								title="No Explain Results"
+								description="Analyze your query's execution plan to understand how the database processes it."
+							>
+								{#snippet actions()}
 									<div class="flex gap-2 justify-center">
 										<Button size="sm" variant="outline" onclick={() => handleExplain(false)}>
 											Explain
@@ -688,26 +680,25 @@ import { errorToast } from "$lib/utils/toast";
 											Explain Analyze
 										</Button>
 									</div>
-								</div>
-							</div>
+								{/snippet}
+							</EmptyState>
 						{:else if currentViewMode === 'visualize' && visualizeResult}
 							<VisualizeResultPane
 								{visualizeResult}
 								layoutOptions={visualizeLayoutOptions}
 							/>
 						{:else if currentViewMode === 'visualize' && !visualizeResult}
-							<div class="flex-1 flex items-center justify-center p-6">
-								<div class="text-center max-w-xs">
-									<NetworkIcon class="size-10 mx-auto mb-3 opacity-20" />
-									<p class="font-medium mb-2">No Visual Results</p>
-									<p class="text-xs text-muted-foreground mb-4">
-										See a visual representation of your query structure.
-									</p>
+							<EmptyState
+								icon={NetworkIcon}
+								title="No Visual Results"
+								description="See a visual representation of your query structure."
+							>
+								{#snippet actions()}
 									<Button size="sm" onclick={handleVisualize}>
 										Visualize Query
 									</Button>
-								</div>
-							</div>
+								{/snippet}
+							</EmptyState>
 						{:else if activeResult?.isError}
 							<QueryErrorDisplay
 								statementIndex={activeResultIndex}
@@ -768,13 +759,12 @@ import { errorToast } from "$lib/utils/toast";
 						{#if currentViewMode === 'explain' && explainResult}
 							<ExplainResultPane {explainResult} />
 						{:else if currentViewMode === 'explain' && !explainResult}
-							<div class="flex-1 flex items-center justify-center p-6">
-								<div class="text-center max-w-xs">
-									<DatabaseIcon class="size-10 mx-auto mb-3 opacity-20" />
-									<p class="font-medium mb-2">No Explain Results</p>
-									<p class="text-xs text-muted-foreground mb-4">
-										Analyze your query's execution plan to understand how the database processes it.
-									</p>
+							<EmptyState
+								icon={DatabaseIcon}
+								title="No Explain Results"
+								description="Analyze your query's execution plan to understand how the database processes it."
+							>
+								{#snippet actions()}
 									<div class="flex gap-2 justify-center">
 										<Button size="sm" variant="outline" onclick={() => handleExplain(false)}>
 											Explain
@@ -783,26 +773,25 @@ import { errorToast } from "$lib/utils/toast";
 											Explain Analyze
 										</Button>
 									</div>
-								</div>
-							</div>
+								{/snippet}
+							</EmptyState>
 						{:else if currentViewMode === 'visualize' && visualizeResult}
 							<VisualizeResultPane
 								{visualizeResult}
 								layoutOptions={visualizeLayoutOptions}
 							/>
 						{:else if currentViewMode === 'visualize' && !visualizeResult}
-							<div class="flex-1 flex items-center justify-center p-6">
-								<div class="text-center max-w-xs">
-									<NetworkIcon class="size-10 mx-auto mb-3 opacity-20" />
-									<p class="font-medium mb-2">No Visual Results</p>
-									<p class="text-xs text-muted-foreground mb-4">
-										See a visual representation of your query structure.
-									</p>
+							<EmptyState
+								icon={NetworkIcon}
+								title="No Visual Results"
+								description="See a visual representation of your query structure."
+							>
+								{#snippet actions()}
 									<Button size="sm" onclick={handleVisualize}>
 										Visualize Query
 									</Button>
-								</div>
-							</div>
+								{/snippet}
+							</EmptyState>
 						{:else}
 							<div class="flex-1 flex items-center justify-center p-6 overflow-auto">
 								<div class="w-full max-w-md space-y-6">

--- a/src/lib/components/standalone-query-editor.svelte
+++ b/src/lib/components/standalone-query-editor.svelte
@@ -34,7 +34,9 @@
 
 	let { executor, value = '', onSqlChange, onExecutingChange, schema, enableVisualSync = false }: Props = $props();
 
-	// Get query builder for two-way sync (only if enabled)
+	// Get query builder for two-way sync (only if enabled at mount time).
+	// enableVisualSync is only read at init; getContext() must run during component initialization.
+	// svelte-ignore state_referenced_locally
 	const qb = enableVisualSync ? useQueryBuilder() : null;
 
 	// Local state

--- a/src/lib/components/ui/empty-state/empty-state.svelte
+++ b/src/lib/components/ui/empty-state/empty-state.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import type { Snippet } from "svelte";
+	import type { Component } from "svelte";
+
+	interface Props {
+		icon: Component<{ class?: string }>;
+		title: string;
+		description?: string;
+		actions?: Snippet;
+		class?: string;
+	}
+
+	let { icon: Icon, title, description, actions, class: className = "" }: Props = $props();
+</script>
+
+<div class="flex-1 flex items-center justify-center p-6 {className}">
+	<div class="text-center max-w-xs">
+		<Icon class="size-10 mx-auto mb-3 opacity-20" />
+		<p class="font-medium mb-2">{title}</p>
+		{#if description}
+			<p class="text-xs text-muted-foreground mb-4">
+				{description}
+			</p>
+		{/if}
+		{#if actions}
+			{@render actions()}
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/ui/empty-state/index.ts
+++ b/src/lib/components/ui/empty-state/index.ts
@@ -1,0 +1,1 @@
+export { default as EmptyState } from "./empty-state.svelte";

--- a/src/lib/hooks/database/schema-tabs.svelte.ts
+++ b/src/lib/hooks/database/schema-tabs.svelte.ts
@@ -5,6 +5,7 @@ import { BaseTabManager, type TabStateAccessors } from './base-tab-manager.svelt
 import { getAdapter, type DatabaseAdapter } from '$lib/db';
 import { mssqlQuery } from '$lib/services/mssql';
 import type { ProviderRegistry } from '$lib/providers';
+import { handleError, createError } from '$lib/errors';
 
 /**
  * Manages schema tabs: add, remove, set active.
@@ -216,7 +217,15 @@ export class SchemaTabManager extends BaseTabManager<SchemaTab> {
 					};
 				}
 			} catch (error) {
-				console.error(`Failed to load metadata for table ${table.schema}.${table.name}:`, error);
+				handleError(
+					createError(
+						'SCHEMA_LOAD_FAILED',
+						error instanceof Error ? error.message : String(error),
+						`Failed to load metadata for ${table.schema}.${table.name}`,
+						{ table: table.name, schema: table.schema }
+					),
+					{ silent: true }
+				);
 			}
 		});
 

--- a/src/lib/utils/clipboard.ts
+++ b/src/lib/utils/clipboard.ts
@@ -1,0 +1,31 @@
+import { toast } from 'svelte-sonner';
+import { m } from '$lib/paraglide/messages.js';
+
+/**
+ * Copy a single cell value to clipboard.
+ */
+export async function copyCell(value: unknown): Promise<void> {
+	const text = value === null || value === undefined ? '' : String(value);
+	await navigator.clipboard.writeText(text);
+	toast.success(m.query_cell_copied());
+}
+
+/**
+ * Copy an entire row as formatted JSON to clipboard.
+ */
+export async function copyRowAsJSON(row: Record<string, unknown>): Promise<void> {
+	await navigator.clipboard.writeText(JSON.stringify(row, null, 2));
+	toast.success(m.query_row_copied());
+}
+
+/**
+ * Copy all values of a column to clipboard, one per line.
+ */
+export async function copyColumn(column: string, rows: Record<string, unknown>[]): Promise<void> {
+	const values = rows
+		.map((row) => row[column])
+		.map((v) => (v === null || v === undefined ? '' : String(v)))
+		.join('\n');
+	await navigator.clipboard.writeText(values);
+	toast.success(m.query_column_copied());
+}


### PR DESCRIPTION
## Summary
- Extract duplicated clipboard ops (`copyCell`, `copyRowAsJSON`, `copyColumn`) into `src/lib/utils/clipboard.ts`, used by `query-editor.svelte` and `result-node.svelte`
- Create reusable `EmptyState` component (`src/lib/components/ui/empty-state/`) replacing 4 duplicated empty-state blocks in the query editor
- Extract shared canvas node logic (`useCanvasNode()`) into `use-canvas-node.svelte.ts`, adopted by all 4 canvas node components
- Migrate `PersistenceManager`, `ExplainTabManager`, and `SchemaTabManager` to centralized `withErrorHandling`/`handleError`
- Fix all 5 `svelte-check` warnings (0 errors, 0 warnings)

## Test plan
- [ ] Verify clipboard copy operations work in query results (right-click → copy cell/row/column)
- [ ] Verify empty states display correctly in query editor (Explain, Visualize tabs)
- [ ] Verify canvas node interactions (remove, resize) work for all node types
- [ ] Verify error toasts appear on persistence and explain failures
- [ ] Run `npm run check` — passes with 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)