### PR TITLE
fix: handle stable versions in Windows version transform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,8 @@ jobs:
           $config = Get-Content $configPath -Raw
           # Transform 2026.4.0-beta.1 → 26.4.0-1
           $config = $config -replace '"version":\s*"20(\d{2})\.(\d+)\.(\d+)-(alpha|beta)\.(\d+)"', '"version": "$1.$2.$3-$5"'
+          # Transform 2026.4.0 → 26.4.0
+          $config = $config -replace '"version":\s*"20(\d{2})\.(\d+)\.(\d+)"', '"version": "$1.$2.$3"'
           Set-Content $configPath $config
           Write-Host "Transformed version for Windows build"
 


### PR DESCRIPTION
## Summary
- Fix Windows version transform to also handle stable releases
- Previously only prerelease versions (2026.4.0-beta.1 → 26.4.0-1) were transformed
- Now stable versions are also transformed (2026.4.0 → 26.4.0)

## Test plan
- [ ] Release v2026.4.0 and verify Windows builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)